### PR TITLE
Resolve possible confusion of event time progress row

### DIFF
--- a/public/locales/en/event.json
+++ b/public/locales/en/event.json
@@ -6,6 +6,8 @@
     "title[2]": "Character"
   },
   "alreadyPast": "Already Past",
+  "remainingTime": "Remaining Time",
+  "progress": "Progress",
   "boostAttribute": "Boost Attribute",
   "boostCharacters": "Boost Charaters",
   "maxBoost": "Max Boost (Both Matched)",

--- a/public/locales/ko/event.json
+++ b/public/locales/ko/event.json
@@ -6,6 +6,8 @@
     "title[2]": "캐릭터"
   },
   "alreadyPast": "경과일",
+  "remainingTime": "남은 시간",
+  "progress": "진행률",
   "boostAttribute": "부스트 속성",
   "boostCharacters": "부스트 캐릭터",
   "maxBoost": "최대 부스트 (두 조건 모두 충족)",

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -60,7 +60,7 @@ const EventDetail: React.FC<{}> = () => {
   const [imgTabVal, setImgTabVal] = useState<string>("0");
   // const [intervalId, setIntervalId] = useState<number>();
   const [nextRefreshTime, setNextRefreshTime] = useState<moment.Moment>();
-  const [pastTime, setPastTime] = useState<string>("");
+  const [remainingTime, setRemainingTime] = useState<string>("");
   const [pastTimePercent, setPastTimePercent] = useState<number>(0);
 
   useEffect(() => {
@@ -106,8 +106,8 @@ const EventDetail: React.FC<{}> = () => {
 
   useEffect(() => {
     if (event && Date.now() < event.aggregateAt) {
-      setPastTime(
-        new Date(Date.now() - event.startAt)
+      setRemainingTime(
+        new Date(event.aggregateAt - Date.now())
           .toISOString()
           .substring(8, 16)
           .replace("T", " day(s) ")
@@ -129,10 +129,10 @@ const EventDetail: React.FC<{}> = () => {
       const interval = window.setInterval(() => {
         if (Date.now() > event.aggregateAt) {
           window.clearInterval(interval);
-          setPastTime(t("event:already-ended"));
+          setRemainingTime(t("event:already-ended"));
           return;
         }
-        setPastTime(
+        setRemainingTime(
           new Date(Date.now() - event.startAt)
             .toISOString()
             .substring(8, 16)
@@ -156,7 +156,7 @@ const EventDetail: React.FC<{}> = () => {
         window.clearInterval(interval);
       };
     } else {
-      setPastTime(t("event:already-ended"));
+      setRemainingTime(t("event:already-ended"));
       setPastTimePercent(100);
     }
   }, [event, t]);
@@ -327,9 +327,9 @@ const EventDetail: React.FC<{}> = () => {
             alignItems="center"
           >
             <Typography variant="subtitle1" style={{ fontWeight: 600 }}>
-              {t("event:alreadyPast")}
+              {t("event:remainingTime")} ({t("event:progress")})
             </Typography>
-            <Typography>{pastTime}</Typography>
+            <Typography>{remainingTime}</Typography>
           </Grid>
           <LinearProgress variant="determinate" value={pastTimePercent} />
           <Divider style={{ margin: "1% 0" }} />

--- a/src/components/EventDetail.tsx
+++ b/src/components/EventDetail.tsx
@@ -133,7 +133,7 @@ const EventDetail: React.FC<{}> = () => {
           return;
         }
         setRemainingTime(
-          new Date(Date.now() - event.startAt)
+          new Date(event.aggregateAt - Date.now())
             .toISOString()
             .substring(8, 16)
             .replace("T", " day(s) ")


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/10243897/96595532-bc135280-1326-11eb-92a1-f25b1b6863d5.png)

## After
![image](https://user-images.githubusercontent.com/10243897/96601380-eb2cc280-132c-11eb-87e8-a247d12fb4bb.png)

## Other changes
### 1. Rename state and event in React tsx
- `[pastTime, setPastTime]` -> `[remainingTime, setRemainingTime]`
### 2. Separate keys
- `alreadyPast` -> `remainingTime` and `progress`
- Please add them to transifex..!!
### 3. Fill new i18n key value (English and Korean only)


