### PR TITLE
layout: place the media element at the top of the media card

### DIFF
--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -2,7 +2,7 @@ import {
   Button,
   ButtonGroup,
   Card,
-  CardHeader,
+  CardContent,
   CardMedia,
   Grid,
   makeStyles,
@@ -239,27 +239,17 @@ const CardList: React.FC<{ contentTransMode: ContentTransModeType }> = (
             className={classes.card}
             // onClick={() => push(path + "/" + data.id)}
           >
-            <CardHeader
-              title={data.prefix}
-              titleTypographyProps={{
-                variant: "subtitle1",
-                classes: {
-                  root: classes.subheader,
-                },
-              }}
-              subheader={getCharaName(charas, data.characterId)}
-              subheaderTypographyProps={{
-                variant: "body2",
-                classes: {
-                  root: classes.subheader,
-                },
-              }}
-            ></CardHeader>
             <CardMedia
               className={classes.media}
               image={`https://sekai-res.dnaroma.eu/file/sekai-assets/character/member_small/${data.assetbundleName}_rip/card_normal.webp`}
               title={data.prefix}
             ></CardMedia>
+            <CardContent>
+              <Typography variant="subtitle1" className={classes.subheader}>{data.prefix}</Typography>
+              <Typography variant="body2" className={classes.subheader} color="textSecondary">
+                {getCharaName(charas, data.characterId)}
+              </Typography>
+            </CardContent>
           </Card>
         </Link>
       );
@@ -356,11 +346,15 @@ const CardList: React.FC<{ contentTransMode: ContentTransModeType }> = (
   const ListLoading: React.FC<any> = () => {
     return (
       <Card className={classes.card}>
-        <CardHeader
-          title={<Skeleton variant="text" width="50%"></Skeleton>}
-          subheader={<Skeleton variant="text" width="80%"></Skeleton>}
-        ></CardHeader>
-        <Skeleton variant="rect" height={130}></Skeleton>
+        <Skeleton variant="rect" className={classes.media}></Skeleton>
+        <CardContent>
+          <Typography variant="subtitle1" className={classes.subheader}>
+            <Skeleton variant="text" width="50%"></Skeleton>
+          </Typography>
+          <Typography variant="body2" className={classes.subheader}>
+            <Skeleton variant="text" width="80%"></Skeleton>
+          </Typography>
+        </CardContent>
       </Card>
     );
   };

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -1,6 +1,6 @@
 import {
   Card,
-  CardHeader,
+  CardContent,
   CardMedia,
   makeStyles,
   Typography,
@@ -106,21 +106,19 @@ const EventList: React.FC<{ contentTransMode: ContentTransModeType }> = () => {
             className={classes.card}
             onClick={() => push(path + "/" + data.id)}
           >
-            <CardHeader
-              title={data.name}
-              titleTypographyProps={{
-                variant: "subtitle1",
-                classes: {
-                  root: classes.header,
-                },
-              }}
-              subheader={t(`event:type.${data.eventType}`)}
-            ></CardHeader>
             <CardMedia
               className={classes.media}
               image={`https://sekai-res.dnaroma.eu/file/sekai-assets/event/${data.assetbundleName}/logo_rip/logo.webp`}
               title={data.name}
             ></CardMedia>
+            <CardContent>
+              <Typography variant="subtitle1" className={classes.header}>
+                {data.name}
+              </Typography>
+              <Typography variant="body2" color="textSecondary">
+                {t(`event:type.${data.eventType}`)}
+              </Typography>
+            </CardContent>
           </Card>
         </Link>
       );
@@ -130,11 +128,15 @@ const EventList: React.FC<{ contentTransMode: ContentTransModeType }> = () => {
   const ListLoading: React.FC<any> = () => {
     return (
       <Card className={classes.card}>
-        <CardHeader
-          title={<Skeleton variant="text" width="50%"></Skeleton>}
-          subheader={<Skeleton variant="text" width="80%"></Skeleton>}
-        ></CardHeader>
-        <Skeleton variant="rect" height={130}></Skeleton>
+        <Skeleton variant="rect" className={classes.media}></Skeleton>
+        <CardContent>
+          <Typography variant="subtitle1" className={classes.header}>
+            <Skeleton variant="text" width="50%"></Skeleton>
+          </Typography>
+          <Typography variant="body2">
+            <Skeleton variant="text" width="80%"></Skeleton>
+          </Typography>
+        </CardContent>
       </Card>
     );
   };

--- a/src/components/GachaList.tsx
+++ b/src/components/GachaList.tsx
@@ -1,6 +1,6 @@
 import {
   Card,
-  CardHeader,
+  CardContent,
   CardMedia,
   makeStyles,
   Typography,
@@ -151,26 +151,20 @@ const GachaList: React.FC<{ contentTransMode: ContentTransModeType }> = ({
           className={classes.card}
           onClick={() => history.push(path + "/" + data.id)}
         >
-          <CardHeader
-            title={
-              contentTransMode === "original"
-                ? data.name
-                : contentTransMode === "translated"
-                ? assetI18n.t(`gacha_name:${data.id}`)
-                : data.name
-            }
-            titleTypographyProps={{
-              variant: "subtitle1",
-              classes: {
-                root: classes.subheader,
-              },
-            }}
-          ></CardHeader>
           <CardMedia
             className={classes.media}
             image={`https://sekai-res.dnaroma.eu/file/sekai-assets/gacha/${data.assetbundleName}/logo_rip/logo.webp`}
             title={data.name}
           ></CardMedia>
+          <CardContent>
+            <Typography variant="subtitle1" className={classes.subheader}>{
+              contentTransMode === "original"
+                ? data.name
+                : contentTransMode === "translated"
+                ? assetI18n.t(`gacha_name:${data.id}`)
+                : data.name
+            }</Typography>
+          </CardContent>
         </Card>
       </Link>
     );
@@ -179,14 +173,12 @@ const GachaList: React.FC<{ contentTransMode: ContentTransModeType }> = ({
   const ListLoading: React.FC<any> = () => {
     return (
       <Card className={classes.card}>
-        <CardHeader
-          title={<Skeleton variant="text" width="50%"></Skeleton>}
-          subheader={<Skeleton variant="text" width="80%"></Skeleton>}
-          subheaderTypographyProps={{
-            variant: "body2",
-          }}
-        ></CardHeader>
-        <Skeleton variant="rect" height={130}></Skeleton>
+        <Skeleton variant="rect" className={classes.media}></Skeleton>
+        <CardContent>
+          <Typography variant="subtitle1" className={classes.subheader}>
+            <Skeleton variant="text" width="80%"></Skeleton>
+          </Typography>
+        </CardContent>
       </Card>
     );
   };

--- a/src/components/MusicList.tsx
+++ b/src/components/MusicList.tsx
@@ -2,7 +2,7 @@ import {
   Button,
   ButtonGroup,
   Card,
-  CardHeader,
+  CardContent,
   CardMedia,
   Chip,
   Grid,
@@ -195,24 +195,6 @@ const MusicList: React.FC<{
             className={classes.card}
             onClick={() => push(path + "/" + data.id)}
           >
-            <CardHeader
-              title={
-                contentTransMode === "original"
-                  ? data.title
-                  : contentTransMode === "translated"
-                  ? assetI18n.t(`music_titles:${data.id}`)
-                  : data.title
-              }
-              titleTypographyProps={{
-                variant: "subtitle1",
-                classes: {
-                  root: classes.header,
-                },
-              }}
-              subheader={data.categories
-                .map((cat) => musicCategoryToName[cat] || cat)
-                .join(", ")}
-            ></CardHeader>
             <CardMedia
               className={classes.media}
               image={`https://sekai-res.dnaroma.eu/file/sekai-assets/music/jacket/${data.assetbundleName}_rip/${data.assetbundleName}.webp`}
@@ -224,6 +206,20 @@ const MusicList: React.FC<{
                   : data.title
               }
             ></CardMedia>
+            <CardContent>
+              <Typography variant="subtitle1" className={classes.header}>{
+                contentTransMode === "original"
+                  ? data.title
+                  : contentTransMode === "translated"
+                  ? assetI18n.t(`music_titles:${data.id}`)
+                  : data.title
+              }</Typography>
+              <Typography variant="body2" color="textSecondary">{
+                data.categories
+                  .map((cat) => musicCategoryToName[cat] || cat)
+                  .join(", ")
+              }</Typography>
+            </CardContent>
           </Card>
         </Link>
       );
@@ -309,11 +305,15 @@ const MusicList: React.FC<{
   const ListLoading: React.FC<any> = () => {
     return (
       <Card className={classes.card}>
-        <CardHeader
-          title={<Skeleton variant="text" width="50%"></Skeleton>}
-          subheader={<Skeleton variant="text" width="80%"></Skeleton>}
-        ></CardHeader>
-        <Skeleton variant="rect" height={130}></Skeleton>
+        <Skeleton variant="rect" className={classes.media}></Skeleton>
+        <CardContent>
+          <Typography variant="subtitle1" className={classes.header}>
+            <Skeleton variant="text" width="50%"></Skeleton>
+          </Typography>
+          <Typography variant="body2">
+            <Skeleton variant="text" width="80%"></Skeleton>
+          </Typography>
+        </CardContent>
       </Card>
     );
   };


### PR DESCRIPTION
Media cards usually have the media at the top, so I think the current layout is a bit confusing.
This PR moves the media element to the top of the card.

https://material.io/components/cards#card-collections
https://material-ui.com/components/cards/#media

Before | After
:----:|:----:
![before-card](https://user-images.githubusercontent.com/73220460/96710610-41eed680-13d7-11eb-9da1-a315887b941c.png) | ![after-card](https://user-images.githubusercontent.com/73220460/96710620-44513080-13d7-11eb-91de-e815001a2b4a.png)
![before-music](https://user-images.githubusercontent.com/73220460/96710863-9e51f600-13d7-11eb-989b-7f7340802e87.png) | ![after-music](https://user-images.githubusercontent.com/73220460/96710867-a01bb980-13d7-11eb-95a0-89b80571a663.png)
![before-gacha](https://user-images.githubusercontent.com/73220460/96710852-9a25d880-13d7-11eb-8393-080ac5e2879d.png) | ![after-gacha](https://user-images.githubusercontent.com/73220460/96710860-9c883280-13d7-11eb-9b1f-cd3db09346f6.png)
![before-event](https://user-images.githubusercontent.com/73220460/96710836-95612480-13d7-11eb-98bd-e5942fd82fd2.png) | ![after-event](https://user-images.githubusercontent.com/73220460/96710845-97c37e80-13d7-11eb-97e1-78abc9020d19.png)

Feel free to close this PR if you do not like this change.