### PR TITLE
fix(layout): improve card title width

### DIFF
--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -55,10 +55,6 @@ const useStyles = makeStyles((theme) => ({
     whiteSpace: "nowrap",
     overflow: "hidden",
     textOverflow: "ellipsis",
-    // [theme.breakpoints.down("md")]: {
-    //   maxWidth: "200px",
-    // },
-    maxWidth: "250px",
   },
   agendaWrapper: {
     display: "block",
@@ -83,10 +79,7 @@ const useStyles = makeStyles((theme) => ({
     whiteSpace: "nowrap",
     overflow: "hidden",
     textOverflow: "ellipsis",
-    [theme.breakpoints.down("sm")]: {
-      maxWidth: "100%",
-    },
-    maxWidth: "210px",
+    maxWidth: "100%",
   },
 }));
 
@@ -454,7 +447,7 @@ const CardList: React.FC<{ contentTransMode: ContentTransModeType }> = ({
                   </Grid>
                 ) : null}
               </Grid>
-              <Grid item>
+              <Grid item style={{ width: "100%" }}>
                 <Typography
                   classes={{ root: classes.comfyPrefix }}
                   variant="body1"

--- a/src/components/MusicList.tsx
+++ b/src/components/MusicList.tsx
@@ -52,10 +52,6 @@ const useStyles = makeStyles((theme) => ({
     "white-space": "nowrap",
     overflow: "hidden",
     "text-overflow": "ellipsis",
-    [theme.breakpoints.down("md")]: {
-      "max-width": "200px",
-    },
-    "max-width": "250px",
   },
   agendaWrapper: {
     display: "block",


### PR DESCRIPTION
Before | After
:----: | :----:
![before card grid](https://user-images.githubusercontent.com/73220460/96922554-f75e7e80-14ea-11eb-9b30-48b95c4ee2c9.png) | ![after card grid](https://user-images.githubusercontent.com/73220460/96922679-1ceb8800-14eb-11eb-913c-38f553dfb1ad.png)
![before card comfy](https://user-images.githubusercontent.com/73220460/96922563-fa596f00-14ea-11eb-87e1-aded48c5bb93.png) | ![after card comfy](https://user-images.githubusercontent.com/73220460/96922709-27a61d00-14eb-11eb-98ef-a13a8f952600.png)
![before music grid](https://user-images.githubusercontent.com/73220460/96922572-fe858c80-14ea-11eb-9e48-f40b5c8a7653.png) | ![after music grid](https://user-images.githubusercontent.com/73220460/96922740-3391df00-14eb-11eb-9cca-66c8b1a1aaa9.png)

The colors are slightly different, probably because they were taken on different displays.
This commit won't change colors.
