### PR TITLE
Fix CardDetail Component Lag

### DIFF
--- a/src/components/CardDetail.tsx
+++ b/src/components/CardDetail.tsx
@@ -280,12 +280,12 @@ const CardDetail: React.FC<{ contentTransMode: ContentTransModeType }> = ({
     cardId,
     rarities,
     skills,
-    //getCharaName,
+    getCharaName,
     episodes,
     assetI18n,
     assetI18n.language,
     contentTransMode,
-    //assetT,
+    assetT,
   ]);
 
   const handleChange = (event: React.ChangeEvent<{}>, newValue: string) => {

--- a/src/components/CardDetail.tsx
+++ b/src/components/CardDetail.tsx
@@ -280,12 +280,12 @@ const CardDetail: React.FC<{ contentTransMode: ContentTransModeType }> = ({
     cardId,
     rarities,
     skills,
-    getCharaName,
+    //getCharaName,
     episodes,
     assetI18n,
     assetI18n.language,
     contentTransMode,
-    assetT,
+    //assetT,
   ]);
 
   const handleChange = (event: React.ChangeEvent<{}>, newValue: string) => {

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -2,6 +2,7 @@ import i18n, { TOptions } from "i18next";
 import { initReactI18next } from "react-i18next";
 import fetchBackend from "i18next-fetch-backend";
 import detector from "i18next-browser-languagedetector";
+import { useCallback } from "react";
 
 export function initGlobalI18n() {
   return i18n
@@ -80,13 +81,12 @@ assetI18n
   });
 
 export function useAssetI18n() {
-  const assetT = (
-    key: string,
-    original: string,
-    options?: string | TOptions
-  ): string => {
-    const translated = assetI18n.t(key, options);
-    return !Number.isNaN(Number(translated)) ? original : translated;
-  };
+  const assetT = useCallback(
+    (key: string, original: string, options?: string | TOptions): string => {
+      const translated = assetI18n.t(key, options);
+      return !Number.isNaN(Number(translated)) ? original : translated;
+    },
+    []
+  );
   return { assetT, assetI18n };
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -153,30 +153,33 @@ export const musicTagToName: { [key: string]: string } = {
 export function useCharaName(contentTransMode: ContentTransModeType) {
   const [charas] = useCachedData<ICharaProfile>("gameCharacters");
   const { assetT, assetI18n } = useAssetI18n();
-  return (charaId: number): string | undefined => {
-    const chara = charas.find((chara) => chara.id === charaId);
-    if (chara?.firstName) {
-      switch (contentTransMode) {
-        case "original":
-          return `${chara.firstName} ${chara.givenName}`;
-        case "translated":
-          return ["zh-CN", "zh-TW", "ko", "ja"].includes(assetI18n.language)
-            ? `${assetT(
-                `character_name:${charaId}.firstName`,
-                chara.firstName
-              )} ${assetT(
-                `character_name:${charaId}.givenName`,
-                chara.givenName
-              )}`
-            : `${assetT(
-                `character_name:${charaId}.givenName`,
-                chara.givenName
-              )} ${assetT(
-                `character_name:${charaId}.firstName`,
-                chara.firstName
-              )}`;
+  return useCallback(
+    (charaId: number): string | undefined => {
+      const chara = charas.find((chara) => chara.id === charaId);
+      if (chara?.firstName) {
+        switch (contentTransMode) {
+          case "original":
+            return `${chara.firstName} ${chara.givenName}`;
+          case "translated":
+            return ["zh-CN", "zh-TW", "ko", "ja"].includes(assetI18n.language)
+              ? `${assetT(
+                  `character_name:${charaId}.firstName`,
+                  chara.firstName
+                )} ${assetT(
+                  `character_name:${charaId}.givenName`,
+                  chara.givenName
+                )}`
+              : `${assetT(
+                  `character_name:${charaId}.givenName`,
+                  chara.givenName
+                )} ${assetT(
+                  `character_name:${charaId}.firstName`,
+                  chara.firstName
+                )}`;
+        }
       }
-    }
-    return chara?.givenName;
-  };
+      return chara?.givenName;
+    },
+    [assetI18n.language, assetT, charas, contentTransMode]
+  );
 }


### PR DESCRIPTION
`getCharaName` and `assetT` are functions redefined in every rendering progress while caused the `useEffect` called in every rendering progress. `useEffect` calls `setState` in it's function which made the component rendered after `useEffect`. The two facts caused the `CardDetail` component lag.

### 中文
经过排查，`getCharaName`和`assetT`作为一个普通函数变量会在每次渲染执行时被重定义造成地址变动，React不知道函数的内容是否改变，只知道函数的地址发生了改变，从而认为`useEffect`的依赖发生了变更导致重复调用`useEffect`。而`useEffect`的过程中会对state进行改变，这一行为会使得React进行重新渲染。这样一个链式过程（`useEffect`->`setState`->重新渲染->函数不相等->`useEffect`……）导致了`CardDetail`组件一直在进行无效的重复渲染从而发生卡顿。
对于下一步的修复方案，建议将`getCharaName`和`assetT`封装成callback的形式，来规避函数地址变动的问题。