### PR TITLE
build: separate build and deploy jobs of DeployToGHPages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,10 @@
-name: DeployToGHPages
+name: "main: Build & Deploy"
 on:
   push:
     branches:
       - main
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -36,11 +36,31 @@ jobs:
       -
         name: Install packages
         run: npm ci
+
       -
         name: Build pages
         run: npm run build
+
       -
-        name: Deploy to gh-pages
+        name: Store build result
+        uses: actions/upload-artifact@v2
+        with:
+          name: pages
+          path: build/
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      -
+        name: Fetch build result
+        uses: actions/download-artifact@v2
+        with:
+          name: pages
+          path: build/
+
+      -
+        name: Deploy
         uses: crazy-max/ghaction-github-pages@v2.1.3
         with:
           target_branch: gh-pages

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -1,4 +1,4 @@
-name: "PR: Remove Preview after closed"
+name: "PR: Remove preview on close"
 on:
   pull_request_target:
     types: [closed]
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Reomove preview branch
+        name: Remove preview branch
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.PR_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Separate build and deploy jobs of DeployToGHPages.  
Also some texts are changed.

## Motivation and Context

To improve security.  
More specifically, to prevent secrets from being exposed if a dependency contains malicious code (e.g., overwriting `git` commands).

## How Has This Been Tested?

https://github.com/Build774/sekai-viewer/actions/runs/337292298  
https://build774.github.io/sekai-viewer/  