### PR TITLE
refactor(ComicList): modify gridSize for large screen, add viewer upon click

### DIFF
--- a/src/components/ComicList.tsx
+++ b/src/components/ComicList.tsx
@@ -116,9 +116,9 @@ const ComicList: React.FC<{
     setIsReady(Boolean(tipsCache.length));
   }, [setIsReady, tipsCache]);
 
-  const ListCard: React.FC<{ data?: ITipInfoComic; id?: number }> = ({
+  const ListCard: React.FC<{ data?: ITipInfoComic; index?: number }> = ({
     data,
-    id,
+    index,
   }) => {
     if (!data) {
       // loading
@@ -142,7 +142,7 @@ const ComicList: React.FC<{
       <Card className={classes.card}>
         <CardMedia
           onClick={() => {
-            setActiveIdx(id!);
+            setActiveIdx(index!);
             setVisible(true);
           }}
           className={classes.media}

--- a/src/components/subs/InfiniteScroll.tsx
+++ b/src/components/subs/InfiniteScroll.tsx
@@ -43,7 +43,7 @@ type CompleteGridSizeOptions = {
 };
 
 interface IISProps<T> {
-  readonly viewComponent: React.FC<{ data?: T; id?: number }>;
+  readonly viewComponent: React.FC<{ data?: T; index?: number }>;
   readonly callback: (
     entries: readonly IntersectionObserverEntry[],
     setHasMore: React.Dispatch<React.SetStateAction<boolean>>
@@ -151,7 +151,7 @@ function InfiniteScroll<T>({
                 lg={gridSize.lg}
                 xl={gridSize.xl}
               >
-                {viewComponent({ data, id: i })}
+                {viewComponent({ data, index: i })}
               </Grid>
             ))
           : null}

--- a/src/components/subs/InfiniteScroll.tsx
+++ b/src/components/subs/InfiniteScroll.tsx
@@ -43,7 +43,7 @@ type CompleteGridSizeOptions = {
 };
 
 interface IISProps<T> {
-  readonly viewComponent: React.FC<{ data?: T }>;
+  readonly viewComponent: React.FC<{ data?: T; id?: number }>;
   readonly callback: (
     entries: readonly IntersectionObserverEntry[],
     setHasMore: React.Dispatch<React.SetStateAction<boolean>>
@@ -151,7 +151,7 @@ function InfiniteScroll<T>({
                 lg={gridSize.lg}
                 xl={gridSize.xl}
               >
-                {viewComponent({ data })}
+                {viewComponent({ data, id: i })}
               </Grid>
             ))
           : null}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
set lg size to 3 and md to 4, add image viewer component for preview and enlarge comic without open new image directly.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/9821322/97817988-fcb48980-1c9f-11eb-9f1b-34e2022063d2.png)
![image](https://user-images.githubusercontent.com/9821322/97818006-279edd80-1ca0-11eb-9413-027efe7da313.png)
