### PR TITLE
Exclude sourcemap files which are generated when running create-react-app build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
   },
   "scripts": {
     "start": "cross-env TSC_WATCHFILE=UseFsEventsWithFallbackDynamicPolling react-scripts start",
-    "build": "GENERATE_SOURCEMAP=false react-scripts build",
-    "winbuild": "set \"GENERATE_SOURCEMAP=false\" && react-scripts build",
+    "build": "cross-env GENERATE_SOURCEMAP=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "exti18n": "i18next -c ./i18next-parser.config.js -s",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   },
   "scripts": {
     "start": "cross-env TSC_WATCHFILE=UseFsEventsWithFallbackDynamicPolling react-scripts start",
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
+    "winbuild": "set \"GENERATE_SOURCEMAP=false\" && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "exti18n": "i18next -c ./i18next-parser.config.js -s",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added `GENERATE_SOURCEMAP=false` into (npm run)`build` script in `package.json`.
Since syntax of assiging variables are different from Windows and Linux/UNIX shell, I also added (npm run)`winbuild` for Windows.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
> This website reveals source code despite of production build #298 

## Motivation and Context
Prevent web page from being revealed its source code 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Built on my desktop, and tested on my private server.
It can be checked via DevTools of browser regardless of cors issue and etc.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before | After
:---:|:---:
![image](https://user-images.githubusercontent.com/10243897/103405753-8519b280-4b9b-11eb-89dd-aae1816a0aab.png) | ![image](https://user-images.githubusercontent.com/10243897/103405778-9b277300-4b9b-11eb-8ff8-6c961e8b52c4.png)


