### PR TITLE
feat: skill filter for cardList

### DIFF
--- a/src/components/card/CardList.tsx
+++ b/src/components/card/CardList.tsx
@@ -227,9 +227,13 @@ const CardList: React.FC<{}> = () => {
       if (skillSelected.length) {
         result = result.filter((c) => {
           let skill = skills.find((s) => c.skillId === s.id);
-          return skill
-            ? skillSelected.includes(skill.descriptionSpriteName)
-            : true;
+          if (skill) {
+            let descriptionSpriteName = skill.descriptionSpriteName;
+            if (skill.skillEffects[0].activateNotesJudgmentType === "perfect")
+              descriptionSpriteName = "perfect_score_up";
+            return skillSelected.includes(descriptionSpriteName);
+          }
+          return true;
         });
       }
       // temporarily sort cards cache

--- a/src/stores/reducers.ts
+++ b/src/stores/reducers.ts
@@ -57,6 +57,25 @@ export function raritySelectReducer(
   }
 }
 
+export function skillSelectReducer(
+  state: string[],
+  action: { type: "add" | "remove" | "reset"; payload: string }
+) {
+  switch (action.type) {
+    case "add":
+      return [...state, action.payload];
+    case "remove":
+      return [
+        ...state.slice(0, state.indexOf(action.payload)),
+        ...state.slice(state.indexOf(action.payload) + 1),
+      ];
+    case "reset":
+      return [];
+    default:
+      throw new Error();
+  }
+}
+
 export function missionTypeReducer(
   state: string[],
   action: { type: "add" | "remove" | "reset"; payload: string }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implementation of skill filter in card listing page. 
Currently there's no mechanism for "PERFECTのときのみスコアＵＰ" detection, another PR on ```sekai-master-db-diff``` maybe needed for this type of skill.
[Ref](https://github.com/Sekai-World/sekai-master-db-diff/blob/master/skills.json)

## Related Issue
#321 

## Motivation and Context
#321 

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [x] Chrome (Mobile)
- [x] Firefox (Desktop)
- [x] Firefox (Mobile)
- [x] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/11072158/107080886-d5380480-682c-11eb-99bd-c48fd7b83ce4.png)
