### PR TITLE
fix(team): team power calculation

### DIFF
--- a/src/components/subs/TeamBuilder.tsx
+++ b/src/components/subs/TeamBuilder.tsx
@@ -97,7 +97,7 @@ const TeamBuilder: React.FC<{
 
   const {
     getAreaItemBonus,
-    getCharacterRankBouns,
+    getCharacterRankBonus,
     getHonorBonus,
     getPureTeamPowers,
   } = useTeamCalc();
@@ -439,7 +439,9 @@ const TeamBuilder: React.FC<{
         sekaiProfile.sekaiUserProfile.userAreaItems
       );
 
-      const characterRankBonus = getCharacterRankBouns(
+      console.log(areaItemBonus);
+
+      const characterRankBonus = getCharacterRankBonus(
         sekaiProfile.sekaiUserProfile.userCharacters,
         teamCardsStates
       );
@@ -456,7 +458,7 @@ const TeamBuilder: React.FC<{
     return pureDeckPower;
   }, [
     getAreaItemBonus,
-    getCharacterRankBouns,
+    getCharacterRankBonus,
     getHonorBonus,
     getPureTeamPowers,
     isAutoCalcBonus,

--- a/src/utils/teamCalc.ts
+++ b/src/utils/teamCalc.ts
@@ -164,7 +164,7 @@ export const useTeamCalc = () => {
 
       // team without piapro
       // check all same at first (all piapro or other with piapro same support unit)
-      const cardUnits = userCards.map((card) => card.unit);
+      //const cardUnits = userCards.map((card) => card.unit);
       const cardSupportUnits = userCards.map((card) =>
         card.unit === "piapro" ? card.supportUnit : card.unit
       );

--- a/src/utils/teamCalc.ts
+++ b/src/utils/teamCalc.ts
@@ -169,9 +169,9 @@ export const useTeamCalc = () => {
         card.unit === "piapro" ? card.supportUnit : card.unit
       );
       const cardUnitsAllSame =
-        Array.from(new Set(cardUnits)).length === 1 ||
+        userCards.length === 5 &&
         Array.from(new Set(cardSupportUnits)).length === 1;
-      const cardUnitItemLevels = cardUnits.map((unit) =>
+      const cardUnitItemLevels = cardSupportUnits.map((unit) =>
         itemLevels.filter((il) => il.targetUnit === unit)
       );
       const cardUnitBonusRates = cardUnitItemLevels.map((itemLevels) =>
@@ -195,22 +195,17 @@ export const useTeamCalc = () => {
       const piaproCardIdxs = userCards
         .map((_, idx) => idx)
         .filter((idx) => userCards[idx].supportUnit !== "none");
-      const piaproSupportCards = userCards.filter(
-        (card) => card.supportUnit !== "none"
-      );
+      const piaproCards = userCards.filter((card) => card.unit === "piapro");
+      const isAllPiapro = piaproCards.length === 5;
       const piaproSupportItemLevels = itemLevels.filter(
-        (il) =>
-          il.targetUnit !== "piapro" &&
-          piaproSupportCards.some((card) => card.supportUnit === il.targetUnit)
+        (il) => il.targetUnit === "piapro"
       );
-      const piaproSupportBonusRate = Number(
+      const piaproBonusRate = Number(
         piaproSupportItemLevels
           .reduce(
             (sum, item) =>
               sum +
-              item[
-                cardUnitsAllSame ? "power1AllMatchBonusRate" : "power1BonusRate"
-              ],
+              item[isAllPiapro ? "power1AllMatchBonusRate" : "power1BonusRate"],
             0
           )
           .toPrecision(3)
@@ -219,7 +214,7 @@ export const useTeamCalc = () => {
       piaproCardIdxs.forEach((idx) => {
         cardUnitBonusRates[idx] = Math.max(
           cardUnitBonusRates[idx],
-          piaproSupportBonusRate
+          piaproBonusRate
         );
       });
 
@@ -230,6 +225,8 @@ export const useTeamCalc = () => {
           cardAttrBonusRates[idx] +
           cardUnitBonusRates[idx]
       );
+
+      console.log(sumBonusRates);
 
       return sumBonusRates.reduce(
         (sum, bonusRate, idx) =>
@@ -243,7 +240,7 @@ export const useTeamCalc = () => {
     [areaItemLevels, cards, gameCharas, getUserCardPowers]
   );
 
-  const getCharacterRankBouns = useCallback(
+  const getCharacterRankBonus = useCallback(
     (userCharacters: UserCharacter[], userTeamCardStates: ITeamCardState[]) => {
       if (!characterRanks || !cards || !gameCharas) return -1;
 
@@ -353,7 +350,7 @@ export const useTeamCalc = () => {
 
   return {
     getAreaItemBonus,
-    getCharacterRankBouns,
+    getCharacterRankBonus,
     getHonorBonus,
     getPureTeamPowers,
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix team power calculation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Sekai Viewer calculated incorrect team power when multiple piapro card in the deck.
![Game](https://user-images.githubusercontent.com/3205159/107141320-f13dc200-6962-11eb-948f-43f6435f9843.PNG)
![Viewer](https://user-images.githubusercontent.com/3205159/107141327-fdc21a80-6962-11eb-9a96-1be72cf1ff44.jpg)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Modified the logic of team power calculation.
**UI is not touched.**

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
![Viewer](https://user-images.githubusercontent.com/3205159/107141341-16323500-6963-11eb-8c26-c3bc47e66251.jpg)
