### PR TITLE
feat: link to story reader for card and event stories from details pages

### DIFF
--- a/src/components/card/CardDetail.tsx
+++ b/src/components/card/CardDetail.tsx
@@ -4,6 +4,7 @@ import {
   CardMedia,
   Divider,
   Grid,
+  IconButton,
   makeStyles,
   Paper,
   Slider,
@@ -23,7 +24,7 @@ import React, {
   useEffect,
   useState,
 } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useHistory, useParams } from "react-router-dom";
 import Viewer from "react-viewer";
 import { ImageDecorator } from "react-viewer/lib/ViewerProps";
 
@@ -58,6 +59,8 @@ import {
 import ResourceBox from "../subs/ResourceBox";
 import { AudioPlayButton } from "../storyreader/StoryReaderSnippet";
 import AdSense from "../subs/AdSense";
+
+import { OpenInNew } from "@material-ui/icons";
 
 const useStyles = makeStyles((theme) => ({
   "rarity-star-img": {
@@ -102,6 +105,7 @@ const CardDetail: React.FC<{}> = () => {
   const { assetT, getTranslated } = useAssetI18n();
   const { contentTransMode } = useContext(SettingContext)!;
   const getCharaName = useCharaName();
+  const history = useHistory();
 
   const [charas] = useCachedData<IGameChara>("gameCharacters");
   const [cards] = useCachedData<ICardInfo>("cards");
@@ -1151,6 +1155,31 @@ const CardDetail: React.FC<{}> = () => {
                 </Grid>
               </Grid>
               <Divider style={{ margin: "1% 0" }} />
+              <Grid
+                container
+                direction="row"
+                wrap="nowrap"
+                justify="space-between"
+                alignItems="center"
+              >
+                <Grid item xs={2}>
+                  <Typography variant="subtitle1" style={{ fontWeight: 600 }}>
+                    {t("common:storyReader")}
+                  </Typography>
+                </Grid>
+                <Grid item justify="flex-end">
+                  <IconButton
+                    onClick={() =>
+                      history.push(
+                        `/storyreader/cardStory/${card.characterId}/${card.id}/${cardEpisode[0].id}`
+                      )
+                    }
+                  >
+                    <OpenInNew />
+                  </IconButton>
+                </Grid>
+              </Grid>
+              <Divider style={{ margin: "1% 0" }} />
             </Grid>
           </TabPanel>
           <TabPanel value="2" classes={{ root: classes.tabpanel }}>
@@ -1220,6 +1249,31 @@ const CardDetail: React.FC<{}> = () => {
                       justify="flex-end"
                     />
                   ))}
+                </Grid>
+              </Grid>
+              <Divider style={{ margin: "1% 0" }} />
+              <Grid
+                container
+                direction="row"
+                wrap="nowrap"
+                justify="space-between"
+                alignItems="center"
+              >
+                <Grid item xs={2}>
+                  <Typography variant="subtitle1" style={{ fontWeight: 600 }}>
+                    {t("common:storyReader")}
+                  </Typography>
+                </Grid>
+                <Grid item justify="flex-end">
+                  <IconButton
+                    onClick={() =>
+                      history.push(
+                        `/storyreader/cardStory/${card.characterId}/${card.id}/${cardEpisode[1].id}`
+                      )
+                    }
+                  >
+                    <OpenInNew />
+                  </IconButton>
                 </Grid>
               </Grid>
               <Divider style={{ margin: "1% 0" }} />

--- a/src/components/event/EventDetail.tsx
+++ b/src/components/event/EventDetail.tsx
@@ -497,6 +497,31 @@ const EventDetail: React.FC<{}> = () => {
               <Divider style={{ margin: "1% 0" }} />
             </Fragment>
           )}
+          <Grid
+            item
+            container
+            direction="row"
+            wrap="nowrap"
+            justify="space-between"
+            alignItems="center"
+          >
+            <Grid item xs={4}>
+              <Typography variant="subtitle1" style={{ fontWeight: 600 }}>
+                {t("common:storyReader")}
+              </Typography>
+            </Grid>
+            <Grid item xs={6} container justify="flex-end">
+              <Link
+                to={`/storyreader/eventStory/${eventId}`}
+                className={interactiveClasses.noDecoration}
+              >
+                <Grid container alignItems="center">
+                  <OpenInNew />
+                </Grid>
+              </Link>
+            </Grid>
+          </Grid>
+          <Divider style={{ margin: "1% 0" }} />
         </Grid>
       </Container>
       <Typography variant="h6" className={layoutClasses.header}>


### PR DESCRIPTION
## Description
- Adds a link on the side story tabs to the story reader for that side story
  - Styled after the IconButton link in MemberDetails
- Adds a link on the event details page to the story reader index for that event
  - Styled after the event tracker link directly above it

Not sure if these two different link styles should be different to begin with? The IconButton one seems like it should be used in both places, but I tried to be consistent with existing code.

Labeled with `common:storyReader` since I didn't want to use `member:scenario` out of scope. Didn't know if a new tl item was needed or not.

## Related Issue
#330

## Motivation and Context
#330 
