### PR TITLE
fix(gacha): now able to sample the last element in card-list of each …

### DIFF
--- a/src/components/gacha/GachaDetail.tsx
+++ b/src/components/gacha/GachaDetail.tsx
@@ -208,7 +208,7 @@ const GachaDetailPage: React.FC<{}> = () => {
             const weightSum = weights[2];
             const rand = Math.floor(Math.random() * weightSum);
             tmpGachaResult.push(
-              rollCards[2][weightArr.filter((weight) => weight < rand).length]
+              rollCards[2][weightArr.filter((weight) => weight <= rand).length]
             );
           } else if (roll < must3RollResult[1]) {
             // get 4* card
@@ -224,7 +224,7 @@ const GachaDetailPage: React.FC<{}> = () => {
             const weightSum = weights[3];
             const rand = Math.floor(Math.random() * weightSum);
             tmpGachaResult.push(
-              rollCards[3][weightArr.filter((weight) => weight < rand).length]
+              rollCards[3][weightArr.filter((weight) => weight <= rand).length]
             );
           } else {
             console.log(roll, must3RollResult);
@@ -249,7 +249,7 @@ const GachaDetailPage: React.FC<{}> = () => {
           const weightSum = weights[0];
           const rand = Math.floor(Math.random() * weightSum);
           tmpGachaResult.push(
-            rollCards[0][weightArr.filter((weight) => weight < rand).length]
+            rollCards[0][weightArr.filter((weight) => weight <= rand).length]
           );
           noStar3Count++;
         } else if (roll <= rollResult[1]!) {
@@ -266,7 +266,7 @@ const GachaDetailPage: React.FC<{}> = () => {
           const weightSum = weights[1];
           const rand = Math.floor(Math.random() * weightSum);
           tmpGachaResult.push(
-            rollCards[1][weightArr.filter((weight) => weight < rand).length]
+            rollCards[1][weightArr.filter((weight) => weight <= rand).length]
           );
           noStar3Count++;
         } else if (roll <= rollResult[2]!) {
@@ -283,7 +283,7 @@ const GachaDetailPage: React.FC<{}> = () => {
           const weightSum = weights[2];
           const rand = Math.floor(Math.random() * weightSum);
           tmpGachaResult.push(
-            rollCards[2][weightArr.filter((weight) => weight < rand).length]
+            rollCards[2][weightArr.filter((weight) => weight <= rand).length]
           );
         } else if (roll <= rollResult[3]!) {
           // get 4* card
@@ -299,7 +299,7 @@ const GachaDetailPage: React.FC<{}> = () => {
           const weightSum = weights[3];
           const rand = Math.floor(Math.random() * weightSum);
           tmpGachaResult.push(
-            rollCards[3][weightArr.filter((weight) => weight < rand).length]
+            rollCards[3][weightArr.filter((weight) => weight <= rand).length]
           );
         } else {
           console.log(roll, rollResult);


### PR DESCRIPTION
…rarity

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the behavior of random sampler so that it no longer samples the first element twice probably or samples the last element with zero probability.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#336](https://github.com/Sekai-World/sekai-viewer/issues/336)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix bug

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/50860128/130359824-44c022ed-571d-4ce5-9fc4-d64029a5965c.png)

