### PR TITLE
feat(cards): add correlating event title entry with link

### DIFF
--- a/src/pages/card/CardDetail.tsx
+++ b/src/pages/card/CardDetail.tsx
@@ -32,6 +32,8 @@ import {
   ICardInfo,
   ICardRarity,
   ICharacterRank,
+  IEventCard,
+  IEventInfo,
   IGameChara,
   ISkillInfo,
   IUnitProfile,
@@ -119,6 +121,8 @@ const CardDetail: React.FC<{}> = observer(() => {
   const [charaRanks] = useCachedData<ICharacterRank>("characterRanks");
   const [skills] = useCachedData<ISkillInfo>("skills");
   const [unitProfiles] = useCachedData<IUnitProfile>("unitProfiles");
+  const [eventsCache] = useCachedData<IEventInfo>("events");
+  const [eventCardsCache] = useCachedData<IEventCard>("eventCards");
 
   const { cardId } = useParams<{ cardId: string }>();
 
@@ -138,6 +142,8 @@ const CardDetail: React.FC<{}> = observer(() => {
   // const [maxCardRank, setMaxCardRank] = useState<number>(0);
   const [gachaPhraseUrl, setGachaPhraseUrl] = useState("");
   const [cardCommentId, setCardCommentId] = useState<number>(0);
+
+  const [event, setEvent] = useState<IEventInfo>();
 
   const isBirthdayCard = useMemo(
     () => card?.cardRarityType === "rarity_birthday",
@@ -237,7 +243,11 @@ const CardDetail: React.FC<{}> = observer(() => {
       skills &&
       skills.length &&
       episodes &&
-      episodes.length
+      episodes.length &&
+      eventsCache &&
+      eventsCache.length &&
+      eventCardsCache &&
+      eventCardsCache.length
     ) {
       const _card = cards.find((elem) => elem.id === Number(cardId))!;
       const _rarityInfo = _card.cardRarityType
@@ -270,8 +280,17 @@ const CardDetail: React.FC<{}> = observer(() => {
             window.isChinaMainland ? "cn" : "minio"
           );
       }
+      const _eventCards = eventCardsCache.filter(
+        (elem) => elem.cardId === Number(cardId)
+      );
+      if (_eventCards && _eventCards.length)
+        setEvent(
+          eventsCache.find((elem) => elem.id === Number(_eventCards[0].eventId))
+        );
     }
   }, [
+    eventsCache,
+    eventCardsCache,
     setCard,
     cards,
     cardId,
@@ -722,6 +741,33 @@ const CardDetail: React.FC<{}> = observer(() => {
             </Grid>
           </Grid>
           <Divider style={{ margin: "1% 0" }} />
+          {event ? (
+            // TODO: add a Link navigating to ...
+            <Fragment>
+              <Grid
+                container
+                direction="row"
+                wrap="nowrap"
+                justifyContent="space-between"
+                alignItems="center"
+              >
+                <Grid item>
+                  <Typography variant="subtitle1" style={{ fontWeight: 600 }}>
+                    {t("common:event")}
+                  </Typography>
+                </Grid>
+                <Grid item>
+                  <ContentTrans
+                    contentKey={`event_name:${event.id}`}
+                    original={event.name}
+                    originalProps={{ align: "right" }}
+                    translatedProps={{ align: "right" }}
+                  />
+                </Grid>
+              </Grid>
+              <Divider style={{ margin: "1% 0" }} />
+            </Fragment>
+          ) : null}
           <Grid
             container
             direction="row"

--- a/src/pages/card/CardDetail.tsx
+++ b/src/pages/card/CardDetail.tsx
@@ -742,7 +742,6 @@ const CardDetail: React.FC<{}> = observer(() => {
           </Grid>
           <Divider style={{ margin: "1% 0" }} />
           {event ? (
-            // TODO: add a Link navigating to ...
             <Fragment>
               <Grid
                 container
@@ -757,12 +756,17 @@ const CardDetail: React.FC<{}> = observer(() => {
                   </Typography>
                 </Grid>
                 <Grid item>
-                  <ContentTrans
-                    contentKey={`event_name:${event.id}`}
-                    original={event.name}
-                    originalProps={{ align: "right" }}
-                    translatedProps={{ align: "right" }}
-                  />
+                  <Link
+                    to={`/event/${event.id}`}
+                    className={interactiveClasses.noDecoration}
+                  >
+                    <ContentTrans
+                      contentKey={`event_name:${event.id}`}
+                      original={event.name}
+                      originalProps={{ align: "right" }}
+                      translatedProps={{ align: "right" }}
+                    />
+                  </Link>
                 </Grid>
               </Grid>
               <Divider style={{ margin: "1% 0" }} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
add an entry indicating the corresponding event name of the card with link to the event detail page in between the 'Attribute' entry and the 'Available from' entry.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#361 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
to implement a link to detailed event pages while a user browsing card details.


## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [x] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/50860128/148681279-64c81295-358f-48d5-8c15-55009eebaa72.png)

