### PR TITLE
fix(score): multiroom player skill calculation

### DIFF
--- a/src/utils/scoreCalc.ts
+++ b/src/utils/scoreCalc.ts
@@ -56,9 +56,9 @@ export function useScoreCalc() {
   const getMultiSkillRate = useCallback((skillRates: number[]) => {
     let multiSkillRate = 1 + skillRates[0];
     skillRates.forEach((v, i) => {
-      if (i > 0) multiSkillRate *= 1 + v / 5;
+      if (i > 0) multiSkillRate += v / 5;
     });
-    return multiSkillRate - 1;
+    return multiSkillRate;
   }, []);
   const getMultiAverageSkillRates = useCallback(
     (skillRates: number[]) => {


### PR DESCRIPTION
Changed multi room skill calculation to work off the post anniversary equation instead of the pre anniversary equations. Should fix values being off in high skill and low skill scenarios

## Description
Changed skill equation from:
![image](https://user-images.githubusercontent.com/36570430/176789647-3a39b26a-6a91-4b39-82a7-357be21fc7c7.png)
To:
![image](https://user-images.githubusercontent.com/36570430/176789743-3c659a31-9efb-42f4-b925-9cbfcaa32f10.png)



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Sekai-World/sekai-viewer/issues/403

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes score calculation (and event point calculation) for multiplayer as low skill teams would see noticable fewer event points while high skill teams would see noticably higher event points

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [ ] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
