### PR TITLE
fix: :bug: wrongly trimmed short version of songs

### DIFF
--- a/src/pages/music/MusicDetail.tsx
+++ b/src/pages/music/MusicDetail.tsx
@@ -322,7 +322,8 @@ const MusicDetail: React.FC<{}> = observer(() => {
             ? outCharas.find((elem) => elem.id === chara.characterId)!.name
             : chara.characterId
       );
-      if (trimSilence && format === "mp3") {
+      if (trimSilence && format === "mp3" && vocalPreviewVal === "1") {
+        // only trim when downloading full version
         const buf = (await axios.get(src, { responseType: "arraybuffer" }))
           .data as ArrayBuffer;
         const trimmed = trimMP3(buf, music.fillerSec);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add an extra condition to check if a user is trying to download a full or short song version. If the user decided on the short one, no trim should be applied.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#417 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Short version of music downloaded have first nine seconds trimmed if "Skip beginning silence" was not toggled off in long version tab

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [ ] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [x] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
