### PR TITLE
fix: 🐛 music difficulty background colors

### DIFF
--- a/src/components/styled/ChipDifficulty.tsx
+++ b/src/components/styled/ChipDifficulty.tsx
@@ -8,19 +8,19 @@ type Props = {
 } & ChipProps;
 
 const ChipDifficultyStyled = styled(Chip)(() => ({
-  "& .chip-bg-easy": {
+  "&.chip-bg-easy": {
     backgroundColor: "#86DA45",
   },
-  "& .chip-bg-normal": {
+  "&.chip-bg-normal": {
     backgroundColor: "#5FB8E6",
   },
-  "& .chip-bg-hard": {
+  "&.chip-bg-hard": {
     backgroundColor: "#F3AE3C",
   },
-  "& .chip-bg-expert": {
+  "&.chip-bg-expert": {
     backgroundColor: "#DC5268",
   },
-  "& .chip-bg-master": {
+  "&.chip-bg-master": {
     backgroundColor: "#AC3EE6",
   },
 }));


### PR DESCRIPTION
## Description
Fixed music difficulty background colors.

## Related Issue
N/A

## Motivation and Context
Difficulties were not displaying their corresponding background colors.

## How Has This Been Tested?
- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
![螢幕擷取畫面 2023-10-29 021015](https://github.com/Sekai-World/sekai-viewer/assets/54083835/54225a73-df7d-491e-8e3a-e8bd18b58628)
