### PR TITLE
fix: 🐛 card details not showing for tw, kr region

### DIFF
--- a/src/pages/card/AgendaView.tsx
+++ b/src/pages/card/AgendaView.tsx
@@ -91,7 +91,7 @@ const AgendaView: React.FC<{ data?: ICardInfo }> = ({ data }) => {
           <Grid item xs={6} md={7}>
             <Grid container direction="column" spacing={1}>
               <Grid item>
-                <SpoilerTag releaseTime={new Date(data.releaseAt)} />
+                <SpoilerTag releaseTime={new Date(data.releaseAt ?? data.archivePublishedAt)} />
               </Grid>
               <Grid item>
                 <ContentTrans

--- a/src/pages/card/CardDetail.tsx
+++ b/src/pages/card/CardDetail.tsx
@@ -805,7 +805,9 @@ const CardDetail: React.FC<{}> = observer(() => {
             <Typography variant="subtitle1" style={{ fontWeight: 600 }}>
               {t("common:startAt")}
             </Typography>
-            <Typography>{new Date(card.releaseAt).toLocaleString()}</Typography>
+            <Typography>
+              {new Date(card.releaseAt ?? card.archivePublishedAt).toLocaleString()}
+            </Typography>
           </Grid>
           <Divider style={{ margin: "1% 0" }} />
           <Grid
@@ -1151,11 +1153,13 @@ const CardDetail: React.FC<{}> = observer(() => {
               {t("common:performance")}
             </Typography>
             <Typography>
-              {card.cardParameters.find(
-                (elem) =>
-                  elem.cardParameterType === "param1" &&
-                  elem.cardLevel === cardLevel
-              )?.power! +
+              {(Array.isArray(card.cardParameters)
+                ? card.cardParameters.find(
+                    (elem) =>
+                      elem.cardParameterType === "param1" &&
+                      elem.cardLevel === cardLevel
+                  )?.power!
+                : card.cardParameters["param1"][cardLevel - 1]) +
                 (cardLevel > card.maxNormalLevel
                   ? card.specialTrainingPower1BonusFixed
                   : 0) +
@@ -1185,11 +1189,13 @@ const CardDetail: React.FC<{}> = observer(() => {
               {t("common:technique")}
             </Typography>
             <Typography>
-              {card.cardParameters.find(
-                (elem) =>
-                  elem.cardParameterType === "param2" &&
-                  elem.cardLevel === cardLevel
-              )?.power! +
+              {(Array.isArray(card.cardParameters)
+                ? card.cardParameters.find(
+                    (elem) =>
+                      elem.cardParameterType === "param2" &&
+                      elem.cardLevel === cardLevel
+                  )?.power!
+                : card.cardParameters["param2"][cardLevel - 1]) +
                 (cardLevel > card.maxNormalLevel
                   ? card.specialTrainingPower2BonusFixed
                   : 0) +
@@ -1219,11 +1225,13 @@ const CardDetail: React.FC<{}> = observer(() => {
               {t("common:stamina")}
             </Typography>
             <Typography>
-              {card.cardParameters.find(
-                (elem) =>
-                  elem.cardParameterType === "param3" &&
-                  elem.cardLevel === cardLevel
-              )?.power! +
+              {(Array.isArray(card.cardParameters)
+                ? card.cardParameters.find(
+                    (elem) =>
+                      elem.cardParameterType === "param3" &&
+                      elem.cardLevel === cardLevel
+                  )?.power!
+                : card.cardParameters["param3"][cardLevel - 1]) +
                 (cardLevel > card.maxNormalLevel
                   ? card.specialTrainingPower3BonusFixed
                   : 0) +
@@ -1253,9 +1261,13 @@ const CardDetail: React.FC<{}> = observer(() => {
               {t("common:power")}
             </Typography>
             <Typography>
-              {card.cardParameters
-                .filter((elem) => elem.cardLevel === cardLevel)
-                .reduce((sum, elem) => sum + elem.power, 0) +
+              {(Array.isArray(card.cardParameters)
+                ? card.cardParameters
+                    .filter((elem) => elem.cardLevel === cardLevel)
+                    .reduce((sum, elem) => sum + elem.power, 0)
+                : card.cardParameters["param1"][cardLevel - 1] +
+                  card.cardParameters["param2"][cardLevel - 1] +
+                  card.cardParameters["param3"][cardLevel - 1]) +
                 (cardLevel > card.maxNormalLevel
                   ? card.specialTrainingPower1BonusFixed +
                     card.specialTrainingPower2BonusFixed +

--- a/src/pages/card/ComfyView.tsx
+++ b/src/pages/card/ComfyView.tsx
@@ -99,7 +99,7 @@ const ComfyView: React.FC<{ data?: ICardInfo }> = ({ data }) => {
             <Grid container direction="column" rowSpacing={0.5}>
               <Grid item>
                 <Grid container justifyContent="center">
-                  <SpoilerTag releaseTime={new Date(data.releaseAt)} />
+                  <SpoilerTag releaseTime={new Date(data.releaseAt ?? data.archivePublishedAt)} />
                 </Grid>
               </Grid>
               <Grid item>

--- a/src/pages/card/GridView.tsx
+++ b/src/pages/card/GridView.tsx
@@ -55,7 +55,7 @@ const GridView: React.FC<{ data?: ICardInfo }> = ({ data }) => {
               top: "1%",
               left: "1%",
             }}
-            releaseTime={new Date(data.releaseAt)}
+            releaseTime={new Date(data.releaseAt ?? data.archivePublishedAt)}
           />
         </CardMedia>
         <CardContent style={{ paddingBottom: "16px" }}>

--- a/src/pages/event/EventDetail.tsx
+++ b/src/pages/event/EventDetail.tsx
@@ -163,7 +163,7 @@ const EventDetail: React.FC<{}> = observer(() => {
         Number(eventId) >= 36 ? (Number(eventId) >= 54 ? 2 : 1) : 0;
       setBoostCards(() => {
         let result = cards
-          .filter((elem) => elem.releaseAt <= ev!.aggregateAt)
+          .filter((elem) => (elem.releaseAt ?? elem.archivePublishedAt) <= ev!.aggregateAt)
           .map((card) => {
             let eventCard = ec.find(
               (it) => it.cardId === card.id && it.bonusRate !== undefined

--- a/src/pages/storyreader/StoryReader.tsx
+++ b/src/pages/storyreader/StoryReader.tsx
@@ -669,7 +669,7 @@ const StoryReader: React.FC<{}> = observer(() => {
               const filteredCards = cards.filter(
                 (card) =>
                   card.characterId === Number(charaId) &&
-                  (isShowSpoiler || card.releaseAt <= new Date().getTime())
+                  (isShowSpoiler || (card.releaseAt ?? card.archivePublishedAt) <= new Date().getTime())
               );
               if (filteredCards.length) {
                 return (


### PR DESCRIPTION
## Description
Fix blank page when showing card details in TW, KR region.

## Related Issue
N/A

## Motivation and Context
Also fixed invalid date on card details, missing spoiler tags for unreleased cards, and event bonus cards not showing on event pages.
For whatever reason Nuverse decided to do things differently ¯\_(ツ)_/¯

## How Has This Been Tested?
- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
