### PR TITLE
fix: 🐛 sorting cards by id and release date for tw, kr region

### DIFF
--- a/src/pages/card/CardList.tsx
+++ b/src/pages/card/CardList.tsx
@@ -313,7 +313,9 @@ const CardList: React.FC<{}> = observer(() => {
         case "id":
         case "releaseAt": {
           let sortKey: "id" | "releaseAt" | "archivePublishedAt" = sortBy;
-          if (region === "tw") sortKey = "archivePublishedAt";
+          if (sortKey === "releaseAt" && ["tw", "kr"].includes(region)) {
+            sortKey = "archivePublishedAt";
+          }
           result = result.sort((a, b) =>
             sortType === "asc"
               ? (a[sortKey] || 0) - (b[sortKey] || 0)


### PR DESCRIPTION
## Description
Fix sorting cards by id and release date for tw, kr region.

## Related Issue
N/A

## Motivation and Context
Sorting by id was broken on tw, and sorting by release date was broken on kr.

## How Has This Been Tested?
- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
