### PR TITLE
Add background color for `append` difficulty

### DIFF
--- a/src/components/styled/ChipDifficulty.tsx
+++ b/src/components/styled/ChipDifficulty.tsx
@@ -23,6 +23,9 @@ const ChipDifficultyStyled = styled(Chip)(() => ({
   "&.chip-bg-master": {
     backgroundColor: "#AC3EE6",
   },
+  "&.chip-bg-append": {
+    backgroundColor: "#FF82C4",
+  },
 }));
 
 const ChipDifficulty = (props: Props) => {


### PR DESCRIPTION
## Description
Add background color for the new `append` difficulties in music lists.

## Related Issue
N/A

## Motivation and Context
I think player profiles need to be updated as well?

## How Has This Been Tested?
- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
![螢幕擷取畫面 2023-10-30 211241](https://github.com/Sekai-World/sekai-viewer/assets/54083835/c7c8c803-6d9d-490a-ac44-528ee42562ad)
