### PR TITLE
Fix virtual live music setlists not showing on tw, kr server

### DIFF
--- a/src/pages/virtual_live/VirtualLiveStepMusic.tsx
+++ b/src/pages/virtual_live/VirtualLiveStepMusic.tsx
@@ -23,10 +23,11 @@ const VirtualLiveStepMusic: React.FC<{
   const [musicVocalURL, setMusicVocalURL] = useState<string>("");
 
   useLayoutEffect(() => {
-    if (musics) {
-      setMusic(musics.find((elem) => elem.id === data.musicId!));
+    if (musics && musicVocal) {
+      // for compatibility with tw, kr server
+      setMusic(musics.find((elem) => elem.id === musicVocal.musicId));
     }
-  }, [data.musicId, musics]);
+  }, [musics, musicVocal]);
 
   useLayoutEffect(() => {
     if (musicVocals) {

--- a/src/pages/virtual_live/VirtualLiveStepMusic.tsx
+++ b/src/pages/virtual_live/VirtualLiveStepMusic.tsx
@@ -87,7 +87,10 @@ const VirtualLiveStepMusic: React.FC<{
               </Grid>
             </Grid>
             <Grid item xs={12}>
-              <AudioPlayer src={musicVocalURL} />
+              <AudioPlayer
+                src={musicVocalURL}
+                offset={music.fillerSec}
+              />
             </Grid>
           </Grid>
         </Fragment>


### PR DESCRIPTION
## Description
Fix virtual live music setlists not showing on tw, kr server

## Related Issue
N/A

## Motivation and Context
Also made skipping filler seconds by default. I think it makes more sense here.

## How Has This Been Tested?
- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)