### PR TITLE
fix(live2d): motion path for sanrio models

### DIFF
--- a/src/pages/live2d/Live2D.tsx
+++ b/src/pages/live2d/Live2D.tsx
@@ -420,19 +420,22 @@ const Live2DView: React.FC<unknown> = () => {
   const handleShow = useCallback(() => {
     setModelName(selectedModelName);
     let motionName = selectedModelName;
-    if (motionName) {
-      if (motionName?.startsWith("sub") || motionName?.startsWith("clb")) {
+    if (!motionName) return;
+    if (!motionName.startsWith("v2_sub_sanrio")) {
+      if (motionName.endsWith("black")) {
+        motionName = motionName.slice(0, -5);
+      } else if (
+        motionName?.startsWith("sub") ||
+        motionName?.startsWith("clb")
+      ) {
         motionName = motionName.split("_").slice(0, 2).join("_");
       } else if (motionName.startsWith("v2")) {
         motionName = motionName.split("_")[1]!;
       } else {
         motionName = motionName.split("_")[0]!;
       }
-      if (motionName.endsWith("black")) {
-        motionName = motionName.slice(0, -5);
-      }
-      setMotionName(motionName + "_motion_base");
     }
+    setMotionName(motionName + "_motion_base");
   }, [selectedModelName]);
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Live2D Viewer cannot retrieve correct motion file path for some models. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#482 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix the issue and let the models correctly display.

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [x] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
