### PR TITLE
Feature/disable trim images for cards after 3rd anni

### DIFF
--- a/src/pages/card/CardDetail.tsx
+++ b/src/pages/card/CardDetail.tsx
@@ -378,7 +378,7 @@ const CardDetail: React.FC<unknown> = observer(() => {
 
   const getCardImages: () => ImageDecorator[] = useCallback(
     () =>
-      card
+      (card
         ? isTrainableCard
           ? [
               {
@@ -386,21 +386,25 @@ const CardDetail: React.FC<unknown> = observer(() => {
                 downloadUrl: normalImg.replace(".webp", ".png"),
                 src: normalImg,
               },
-              {
-                alt: "card normal trim",
-                downloadUrl: normalTrimImg.replace(".webp", ".png"),
-                src: normalTrimImg,
-              },
+              normalTrimImg
+                ? {
+                    alt: "card normal trim",
+                    downloadUrl: normalTrimImg.replace(".webp", ".png"),
+                    src: normalTrimImg,
+                  }
+                : undefined,
               {
                 alt: "card after training",
                 downloadUrl: trainedImg.replace(".webp", ".png"),
                 src: trainedImg,
               },
-              {
-                alt: "card after training trim",
-                downloadUrl: trainedTrimImg.replace(".webp", ".png"),
-                src: trainedTrimImg,
-              },
+              trainedTrimImg
+                ? {
+                    alt: "card after training trim",
+                    downloadUrl: trainedTrimImg.replace(".webp", ".png"),
+                    src: trainedTrimImg,
+                  }
+                : undefined,
             ]
           : [
               {
@@ -414,7 +418,8 @@ const CardDetail: React.FC<unknown> = observer(() => {
                 src: normalTrimImg,
               },
             ]
-        : [],
+        : []
+      ).filter((img) => !!img) as ImageDecorator[],
     [
       card,
       isTrainableCard,
@@ -449,13 +454,15 @@ const CardDetail: React.FC<unknown> = observer(() => {
               scrollButtons
             >
               <Tab label={t("card:tab.title[0]")} value="0"></Tab>
-              <Tab label={t("card:tab.title[1]")} value="2"></Tab>
-              {isTrainableCard && !isBirthdayCard ? (
+              {!!normalTrimImg && (
+                <Tab label={t("card:tab.title[1]")} value="2"></Tab>
+              )}
+              {isTrainableCard && !isBirthdayCard && (
                 <Tab label={t("card:tab.title[2]")} value="1"></Tab>
-              ) : null}
-              {isTrainableCard && !isBirthdayCard ? (
+              )}
+              {isTrainableCard && !isBirthdayCard && !!trainedTrimImg && (
                 <Tab label={t("card:tab.title[3]")} value="3"></Tab>
-              ) : null}
+              )}
             </Tabs>
             <TabPanelPadding value="0">
               <Card
@@ -477,32 +484,36 @@ const CardDetail: React.FC<unknown> = observer(() => {
                 <CardMediaCardImg image={trainedImg} />
               </Card>
             </TabPanelPadding>
-            <TabPanelPadding value="2">
-              <Card
-                onClick={() => {
-                  setActiveIdx(1);
-                  setVisible(true);
-                }}
-              >
-                <CardMediaCardImg
-                  image={normalTrimImg}
-                  sx={{ backgroundSize: "contain" }}
-                />
-              </Card>
-            </TabPanelPadding>
-            <TabPanelPadding value="3">
-              <Card
-                onClick={() => {
-                  setActiveIdx(3);
-                  setVisible(true);
-                }}
-              >
-                <CardMediaCardImg
-                  image={trainedTrimImg}
-                  sx={{ backgroundSize: "contain" }}
-                />
-              </Card>
-            </TabPanelPadding>
+            {!!normalTrimImg && (
+              <TabPanelPadding value="2">
+                <Card
+                  onClick={() => {
+                    setActiveIdx(1);
+                    setVisible(true);
+                  }}
+                >
+                  <CardMediaCardImg
+                    image={normalTrimImg}
+                    sx={{ backgroundSize: "contain" }}
+                  />
+                </Card>
+              </TabPanelPadding>
+            )}
+            {!!trainedTrimImg && (
+              <TabPanelPadding value="3">
+                <Card
+                  onClick={() => {
+                    setActiveIdx(3);
+                    setVisible(true);
+                  }}
+                >
+                  <CardMediaCardImg
+                    image={trainedTrimImg}
+                    sx={{ backgroundSize: "contain" }}
+                  />
+                </Card>
+              </TabPanelPadding>
+            )}
           </Paper>
         </TabContext>
         <GridOut container direction="column">

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -335,25 +335,13 @@ export async function getRemoteAssetURL(
   // const isWebpSupported = Modernizr.webplossless;
   const url = `${assetUrl[domainKey][server]}/${endpoint}`;
 
-  // if (endpoint.endsWith(".webp") && !isWebpSupported) {
-  //   let dataUrl = await localforage.getItem<string>(url);
-  //   if (!dataUrl) {
-  //     const res = await Axios.get(url, { responseType: "arraybuffer" });
-  //     dataUrl = await queue.add<string>(() =>
-  //       webpMachine.decode(new Uint8Array(res.data))
-  //     );
-  //     await localforage.setItem(url, dataUrl);
-  //     if (setFunc) setFunc(dataUrl);
-  //     return dataUrl;
-  //   } else {
-  //     // await Axios.head(url);
-  //     if (setFunc) setFunc(dataUrl);
-  //     return dataUrl;
-  //   }
-  // } else
-  // await Axios.head(url);
-  if (setFunc) setFunc(url);
-  return url;
+  const headRes = await Axios.head(url);
+  // console.log(headRes.status, url);
+  if (headRes.status <= 400) {
+    if (setFunc) setFunc(url);
+    return url;
+  }
+  return "";
 }
 
 // export async function getMovieUrl(stringVal: string) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
After 3rd anniversary, the card images with transparent background are not available anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
