### PR TITLE
fix: :bug: v2 models motion path was incorrect

### DIFF
--- a/src/pages/live2d/Live2D.tsx
+++ b/src/pages/live2d/Live2D.tsx
@@ -426,11 +426,10 @@ const Live2DView: React.FC<unknown> = () => {
         motionName = motionName.slice(0, -5);
       } else if (
         motionName?.startsWith("sub") ||
-        motionName?.startsWith("clb")
+        motionName?.startsWith("clb") ||
+        motionName.match(/^v2_\d{2}.*/)
       ) {
         motionName = motionName.split("_").slice(0, 2).join("_");
-      } else if (motionName.startsWith("v2")) {
-        motionName = motionName.split("_")[1]!;
       } else {
         motionName = motionName.split("_")[0]!;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
V2 models (after 3rd anniversary) are still using old v1 motion files.

<!--- ## Related Issue -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Let v2 models use correct motion files.

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [x] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
