### PR TITLE
feat(music): original music video link

### DIFF
--- a/src/components/blocks/EmbedVideoPlayer.tsx
+++ b/src/components/blocks/EmbedVideoPlayer.tsx
@@ -1,0 +1,57 @@
+import React, { Fragment, useEffect, useState } from "react";
+
+const MusicVideoPlayer: React.FC<{
+  videoUrl: string;
+}> = (props) => {
+  const [isYtbVideo, setIsYtbVideo] = useState(false);
+  const [ytbVideoId, setYtbVideoId] = useState("");
+
+  const [isNicoVideo, setIsNicoVideo] = useState(false);
+  const [nicoVideoId, setNicoVideoId] = useState("");
+
+  useEffect(() => {
+    if (props.videoUrl.includes("youtube.com")) {
+      setIsYtbVideo(true);
+      setYtbVideoId(
+        new URLSearchParams(new URL(props.videoUrl).search).get("v") || ""
+      );
+    } else if (props.videoUrl.includes("youtu.be")) {
+      setIsYtbVideo(true);
+      setYtbVideoId(new URL(props.videoUrl).pathname.split("/")[1] || "");
+    } else if (props.videoUrl.includes("nicovideo.jp")) {
+      setIsNicoVideo(true);
+      setNicoVideoId(
+        new URL(props.videoUrl).pathname.split("/")[2].split("?")[0] || ""
+      );
+    }
+  }, [props.videoUrl]);
+
+  return (
+    <Fragment>
+      {isYtbVideo && (
+        <iframe
+          width="100%"
+          height="485"
+          src={`https://www.youtube.com/embed/${ytbVideoId}`}
+          title="YouTube video player"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          style={{ border: "none" }}
+        ></iframe>
+      )}
+      {isNicoVideo && (
+        <iframe
+          width="100%"
+          height="485"
+          src={`https://embed.nicovideo.jp/watch/${nicoVideoId}?autoplay=0`}
+          title="niconico"
+          allowFullScreen
+          allow="encrypted-media *;"
+          style={{ border: "none" }}
+        ></iframe>
+      )}
+    </Fragment>
+  );
+};
+
+export default MusicVideoPlayer;

--- a/src/components/blocks/SekaiGameNews.tsx
+++ b/src/components/blocks/SekaiGameNews.tsx
@@ -45,7 +45,7 @@ function InfoInternal(props: { onClick: () => void }) {
 function InfoInternalDialog(props: {
   url: string;
   open: boolean;
-  onClose: (event: {}, reason: "backdropClick" | "escapeKeyDown") => void;
+  onClose: (event: unknown, reason: "backdropClick" | "escapeKeyDown") => void;
   title: string;
 }) {
   return (

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1563,3 +1563,9 @@ interface ICompactResourceBoxDetailENUM {
   resourceBoxPurpose: string[];
   resourceType: string[];
 }
+
+export interface IMusicOriginal {
+  id: number;
+  musicId: number;
+  videoLink: string;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -76,6 +76,7 @@ import {
   ICompactResourceBox,
   ICompactResourceBoxDetail,
   IGachaTicket,
+  IMusicOriginal,
 } from "./../types.d";
 import { useAssetI18n, useCharaName } from "./i18n";
 import { useLocation } from "react-router-dom";
@@ -154,6 +155,7 @@ export function useCachedData<
     | IMasterLessonReward
     | IEventMusic
     | IGachaTicket
+    | IMusicOriginal
 >(name: string): [T[] | undefined, boolean, any] {
   // const [cached, cachedRef, setCached] = useRefState<T[]>([]);
   const { region } = useRootStore();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Project Sekai have now "Original" indicator for songs with original video.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#475 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Use information from `musicOriginals.json` to display embedded original music video (youtube and niconico).

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [x] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
![image](https://github.com/Sekai-World/sekai-viewer/assets/9821322/87312e9f-9aec-4b93-89b2-97773f589d01)
