### PR TITLE
fix(score): multiroom player skill calculation

### DIFF
--- a/src/utils/scoreCalc.ts
+++ b/src/utils/scoreCalc.ts
@@ -55,7 +55,7 @@ export function useScoreCalc() {
   );
 
   const getMultiSkillRate = useCallback((skillRates: number[]) => {
-    let multiSkillRate = 1 + skillRates[0];
+    let multiSkillRate = skillRates[0];
     skillRates.forEach((v, i) => {
       if (i > 0) multiSkillRate += v / 5;
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix `getMultiSkillRate` form calculating "scale factor" to calculating "rate of change".

## Related Issue

#403 
#404 

## Motivation and Context
The scores in the multiplayer mode calculated by the "Song Recommender" website differ from those shown of the game. 

The `getMultiSkillRate` function previously implemented the formula for "effective skill powers" based on the game's mechanics before the official change. The previous implementation:  
https://github.com/Sekai-World/sekai-viewer/blob/4301ecc6061b89a8510684f47b8cae3d8edabd98/src/utils/scoreCalc.ts#L56-L62  
The old formula was:
$\left(1+ \mathtt{skill}_1\right) \cdot \left(1+ \frac{\mathtt{skill}_2}{5}\right) \cdot \left(1+ \frac{\mathtt{skill}_3}{5}\right) \cdot \left(1+ \frac{\mathtt{skill}_4}{5}\right) \cdot \left(1+ \frac{\mathtt{skill}_5}{5}\right) - 1$,
which represents a "rate of change".

The implementation in `src/utils/scoreCalc.ts` is based on representing an "effective skill power" as a "rate of change" . 

Therefore, the updated formula should also represent a "rate of change," which is: 
$\mathtt{skill}_1 + \frac{\mathtt{skill}_2}{5} + \frac{\mathtt{skill}_3}{5} + \frac{\mathtt{skill}_4}{5} + \frac{\mathtt{skill}_5}{5}$.

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [ ] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
