### PR TITLE
fix(live2d): only one texture was packed when download live2d models

### DIFF
--- a/src/pages/live2d/Live2D.tsx
+++ b/src/pages/live2d/Live2D.tsx
@@ -203,7 +203,10 @@ const Live2DView: React.FC<unknown> = () => {
           return prev;
         }, {}),
         Physics: `${modelName}.physics3.json`,
-        Textures: [`${modelName}.2048/texture_00.png`],
+        Textures: modelData.FileReferences.Textures.map(
+          (_, idx) =>
+            `${modelName}.2048/texture_${idx.toString().padStart(2, "0")}.png`
+        ),
       },
       Groups: [
         {
@@ -224,12 +227,12 @@ const Live2DView: React.FC<unknown> = () => {
 
     setProgress(10);
     setProgressWords(t("live2d:pack_progress.download_texture"));
-    const { data: texture } = await Axios.get(
-      modelData.url + modelData.FileReferences.Textures[0],
-      { responseType: "blob" }
-    );
-
-    zip.file(model3.FileReferences.Textures[0], texture);
+    for (const [idx, t] of modelData.FileReferences.Textures.entries()) {
+      const { data: texture } = await Axios.get(modelData.url + t, {
+        responseType: "blob",
+      });
+      zip.file(model3.FileReferences.Textures[idx], texture);
+    }
 
     setProgress(20);
     setProgressWords(t("live2d:pack_progress.download_moc3"));


### PR DESCRIPTION
## Description

https://sekai.best/l2d
choose v2_clb01_21miku -> show -> download

open it in live2d cubism viewer, and...
![image](https://github.com/user-attachments/assets/de369270-d517-45e0-a5b0-4cef0f99a459)


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [ ] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
