### PR TITLE
fix(live2d): miku missing eye & rui missing arm

### DIFF
--- a/src/utils/Live2DPlayer/Live2DPlayer.ts
+++ b/src/utils/Live2DPlayer/Live2DPlayer.ts
@@ -64,7 +64,7 @@ export class Live2DPlayer {
 
     //initilize stage
     app.stage.removeChildren();
-    app.stage.interactive = false;
+    app.stage.eventMode = "none";
     app.stage.interactiveChildren = false;
     const layer_data: ILive2DLayerData = {
       stage_size: this.stage_size,

--- a/src/utils/Live2DPlayer/layer/Live2D.ts
+++ b/src/utils/Live2DPlayer/layer/Live2D.ts
@@ -20,6 +20,7 @@ import {
   MotionPriority,
   MotionPreloadStrategy,
   config,
+  Cubism4InternalModel,
 } from "pixi-live2d-display-mulmotion";
 config.fftSize = 8192;
 config.logLevel = config.LOG_LEVEL_ERROR;
@@ -85,7 +86,11 @@ export default class Live2D extends BaseLayer {
       motionPreload: motionPreload,
     });
     model.visible = false;
-    model.internalModel.extendParallelMotionManager(2);
+    const internalModel = model.internalModel;
+    if (internalModel instanceof Cubism4InternalModel) {
+      internalModel.coreModel.setOverwriteFlagForModelCullings(true);
+    }
+    internalModel.extendParallelMotionManager(2);
     const alpha = new AlphaFilter(0);
     alpha.resolution = 2;
     model.filters = [alpha];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix the model parts disappear issue by disable back face culling.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [ ] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
