### PR TITLE
Fix possible error on the event tracker for history events

### DIFF
--- a/src/pages/event/EventTracker.tsx
+++ b/src/pages/event/EventTracker.tsx
@@ -556,7 +556,15 @@ const EventTracker: React.FC<unknown> = observer(() => {
                     <Grid key={rank} item xs={12}>
                       <HistoryMobileRow
                         rankingData={
-                          historyRanking.find((elem) => elem.rank === rank)!
+                          historyRanking.find((elem) => elem.rank === rank) || {
+                            id: -1,
+                            eventId: selectedEventId,
+                            timestamp: "0",
+                            rank,
+                            score: 0,
+                            userId: "0",
+                            userName: "N/A",
+                          }
                         }
                         eventId={selectedEvent!.id}
                       />
@@ -592,7 +600,15 @@ const EventTracker: React.FC<unknown> = observer(() => {
                               (r) => r.toRank === rank
                             )}
                           rankingData={
-                            historyRanking.find((elem) => elem.rank === rank)!
+                            historyRanking.find((elem) => elem.rank === rank) || {
+                              id: -1,
+                              eventId: selectedEventId,
+                              timestamp: "0",
+                              rank,
+                              score: 0,
+                              userId: "0",
+                              userName: "N/A",
+                            }
                           }
                           eventDuration={eventDuration}
                           eventId={selectedEvent!.id}

--- a/src/pages/event/EventTrackerMobileRow.tsx
+++ b/src/pages/event/EventTrackerMobileRow.tsx
@@ -17,17 +17,23 @@ export const HistoryMobileRow: React.FC<{
 
   return (
     <Fragment>
-      <Grid container onClick={() => setOpen(!open)} component={Paper}>
+      <Grid
+        container
+        onClick={() => !!rankingData.score && setOpen(!open)}
+        component={Paper}
+      >
         <Grid item xs={12}>
           <Grid container alignItems="center" spacing={1}>
             <Grid item xs={2} sm={1}>
-              <IconButton
-                aria-label="expand row"
-                size="small"
-                onClick={() => setOpen(!open)}
-              >
-                {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
-              </IconButton>
+              {!!rankingData.score && (
+                <IconButton
+                  aria-label="expand row"
+                  size="small"
+                  onClick={() => setOpen(!open)}
+                >
+                  {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+                </IconButton>
+              )}
             </Grid>
             {rankingData.userCheerfulCarnival &&
               rankingData.userCheerfulCarnival.eventId && (
@@ -147,7 +153,7 @@ export const LiveMobileRow: React.FC<{
     <Fragment>
       <Grid
         container
-        onClick={() => setOpen(!open)}
+        onClick={() => !!rankingData.score && setOpen(!open)}
         component={Paper}
         sx={[
           { transition: "background-color 850ms linear" },
@@ -157,13 +163,15 @@ export const LiveMobileRow: React.FC<{
         <Grid item xs={12}>
           <Grid container alignItems="center" spacing={1}>
             <Grid item xs={2} sm={1}>
-              <IconButton
-                aria-label="expand row"
-                size="small"
-                onClick={() => setOpen(!open)}
-              >
-                {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
-              </IconButton>
+              {!!rankingData.score && (
+                <IconButton
+                  aria-label="expand row"
+                  size="small"
+                  onClick={() => setOpen(!open)}
+                >
+                  {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+                </IconButton>
+              )}
             </Grid>
             {rankingData.userCheerfulCarnival &&
               rankingData.userCheerfulCarnival.eventId && (

--- a/src/pages/event/EventTrackerTableRow.tsx
+++ b/src/pages/event/EventTrackerTableRow.tsx
@@ -31,7 +31,7 @@ export const HistoryRow: React.FC<{
             borderBottom: "unset",
           },
         }}
-        key={!!rankingData ? rankingData.userId : 0}
+        key={rankingData.userId}
         onClick={() => setOpen(!open)}
       >
         <TableCell>
@@ -60,8 +60,7 @@ export const HistoryRow: React.FC<{
         </TableCell>
         <TableCell>
           <Grid container alignItems="center" spacing={1}>
-            {!!rankingData &&
-              rankingData.userCheerfulCarnival &&
+            {rankingData.userCheerfulCarnival &&
               rankingData.userCheerfulCarnival.eventId && (
                 <Grid item md={3} lg={2} xl={1}>
                   <CheerfulCarnivalTeamIcon
@@ -74,21 +73,19 @@ export const HistoryRow: React.FC<{
               )}
             <Grid item md={8} lg={9} xl={10}>
               <Typography style={{ minWidth: "100px" }}>
-                {!!rankingData ? rankingData.userName : "N/A"}
+                {rankingData.userName}
               </Typography>
             </Grid>
           </Grid>
         </TableCell>
         <TableCell>
           <Typography align="right" style={{ minWidth: "80px" }}>
-            {!!rankingData ? rankingData.score : "N/A"}
+            {rankingData.score}
           </Typography>
         </TableCell>
         <TableCell>
           <Typography align="right" style={{ minWidth: "80px" }}>
-            {!!rankingData
-              ? Math.round(rankingData.score / (eventDuration / 1000 / 3600))
-              : "N/A"}
+            {Math.round(rankingData.score / (eventDuration / 1000 / 3600))}
           </Typography>
         </TableCell>
       </TableRow>
@@ -97,7 +94,7 @@ export const HistoryRow: React.FC<{
           <Collapse in={open} timeout="auto" unmountOnExit>
             <Grid container alignItems="center" spacing={2}>
               <Grid item xs={2} md={1}>
-                {!!rankingData && !!rankingData.userCard && (
+                {rankingData.userCard && (
                   <CardThumb
                     cardId={rankingData.userCard.cardId}
                     trained={
@@ -110,16 +107,15 @@ export const HistoryRow: React.FC<{
                 <Grid container>
                   <Grid item xs={12}>
                     <Typography variant="subtitle1" fontWeight="bold">
-                      {!!rankingData && rankingData.userName}
+                      {rankingData.userName}
                     </Typography>
-                    {!!rankingData && !!rankingData.userProfile && (
+                    {rankingData.userProfile && (
                       <Typography variant="subtitle2">
-                        {!!rankingData && rankingData.userProfile.word}
+                        {rankingData.userProfile.word}
                       </Typography>
                     )}
                   </Grid>
-                  {!!rankingData &&
-                    !!rankingData.userProfile &&
+                  {rankingData.userProfile &&
                     !rankingData.userProfileHonors && (
                       <Grid item xs={12} container spacing={1}>
                         {rankingData.userProfile.honorId1 && (
@@ -130,7 +126,7 @@ export const HistoryRow: React.FC<{
                             />
                           </Grid>
                         )}
-                        {!!rankingData && rankingData.userProfile.honorId2 && (
+                        {rankingData.userProfile.honorId2 && (
                           <Grid item xs={4} md={3} lg={2}>
                             <DegreeImage
                               honorId={rankingData.userProfile.honorId2}
@@ -138,7 +134,7 @@ export const HistoryRow: React.FC<{
                             />
                           </Grid>
                         )}
-                        {!!rankingData && rankingData.userProfile.honorId3 && (
+                        {rankingData.userProfile.honorId3 && (
                           <Grid item xs={4} md={3} lg={2}>
                             <DegreeImage
                               honorId={rankingData.userProfile.honorId3}
@@ -148,8 +144,7 @@ export const HistoryRow: React.FC<{
                         )}
                       </Grid>
                     )}
-                  {!!rankingData &&
-                    !!rankingData.userProfile &&
+                  {rankingData.userProfile &&
                     rankingData.userProfileHonors && (
                       <Grid item xs={12} container spacing={1}>
                         {rankingData.userProfileHonors.map((honor) => (
@@ -178,12 +173,10 @@ export const HistoryRow: React.FC<{
             <Grid container>
               <Grid item xs={12}>
                 <Grid item xs={12}>
-                  {!!rankingData ? (
-                    <EventTrackerGraph
-                      ranking={rankingData.rank as 1}
-                      eventId={eventId}
-                    />
-                  ) : null}
+                  <EventTrackerGraph
+                    ranking={rankingData.rank as 1}
+                    eventId={eventId}
+                  />
                 </Grid>
               </Grid>
             </Grid>
@@ -381,13 +374,11 @@ export const LiveRow: React.FC<{
             </Grid>
             <Grid container>
               <Grid item xs={12}>
-                {!!rankingData ? (
-                  <EventTrackerGraph
-                    rtRanking={rankingData}
-                    ranking={rankingData.rank as 1}
-                    eventId={rankingData.eventId}
-                  />
-                ) : null}
+                <EventTrackerGraph
+                  rtRanking={rankingData}
+                  ranking={rankingData.rank as 1}
+                  eventId={rankingData.eventId}
+                />
               </Grid>
             </Grid>
           </Collapse>

--- a/src/pages/event/EventTrackerTableRow.tsx
+++ b/src/pages/event/EventTrackerTableRow.tsx
@@ -32,16 +32,18 @@ export const HistoryRow: React.FC<{
           },
         }}
         key={rankingData.userId}
-        onClick={() => setOpen(!open)}
+        onClick={() => !!rankingData.score && setOpen(!open)}
       >
         <TableCell>
-          <IconButton
-            aria-label="expand row"
-            size="small"
-            onClick={() => setOpen(!open)}
-          >
-            {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
-          </IconButton>
+          {!!rankingData.score && (
+            <IconButton
+              aria-label="expand row"
+              size="small"
+              onClick={() => setOpen(!open)}
+            >
+              {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+            </IconButton>
+          )}
         </TableCell>
         <TableCell>
           {rankingReward ? (
@@ -219,7 +221,7 @@ export const LiveRow: React.FC<{
     <Fragment>
       <TableRow
         key={rankingData.userId}
-        onClick={() => setOpen(!open)}
+        onClick={() => !!rankingData.score && setOpen(!open)}
         sx={[
           {
             "& > *": {
@@ -231,13 +233,15 @@ export const LiveRow: React.FC<{
         ]}
       >
         <TableCell>
-          <IconButton
-            aria-label="expand row"
-            size="small"
-            onClick={() => setOpen(!open)}
-          >
-            {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
-          </IconButton>
+          {!!rankingData.score && (
+            <IconButton
+              aria-label="expand row"
+              size="small"
+              onClick={() => setOpen(!open)}
+            >
+              {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+            </IconButton>
+          )}
         </TableCell>
         <TableCell>
           {rankingReward ? (


### PR DESCRIPTION
## Description
Fix possible error on the event tracker for history events due to missing rank data (often occurs on tw and kr).

Also made rows with no score unexpandable, since there's no tracking data to display. Feel free to omit or tweak this change since it's just a minor observation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [x] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
