### PR TITLE
fix(Home): update game walkthrough collection link

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -447,7 +447,7 @@ const Home: React.FC = () => {
             {i18n.language.startsWith("zh") && (
               <Grid item>
                 <Link
-                  href="https://b23.tv/AIjzvc"
+                  href="https://www.bilibili.com/read/readlist/rl330783"
                   target="_blank"
                   underline="hover"
                 >


### PR DESCRIPTION
## Description
The old b23.tv link expired. This PR replaces it with a link to the collection "Project SEKAI 游戏攻略" by xfl03 (xfl33?).

Please help check whether it's the intended link as I cannot trace where the old link redirects to.

## Related Issue
N/A

## Motivation and Context
The old b23.tv short link is dead.

## How Has This Been Tested?
- [ ] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
N/A