### PR TITLE
fix(music meta): fix note count display

### DIFF
--- a/src/pages/MusicRecommend.tsx
+++ b/src/pages/MusicRecommend.tsx
@@ -28,7 +28,7 @@ import {
   // ITeamCardState,
 } from "../types.d";
 import {
-  addLevelToMusicMeta,
+  addDataToMusicMeta,
   filterMusicMeta,
   useCachedData,
   useMusicMeta,
@@ -94,7 +94,7 @@ const MusicRecommend: React.FC<unknown> = () => {
   useEffect(() => {
     if (metas && musics && musicDifficulties) {
       const filteredMetas = filterMusicMeta(metas, musics);
-      setValidMetas(addLevelToMusicMeta(filteredMetas, musicDifficulties));
+      setValidMetas(addDataToMusicMeta(filteredMetas, musicDifficulties));
     }
   }, [metas, musicDifficulties, musics]);
 

--- a/src/pages/music/MusicMeta.tsx
+++ b/src/pages/music/MusicMeta.tsx
@@ -18,7 +18,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { IMusicDifficultyInfo, IMusicInfo, IMusicMeta } from "../../types.d";
 import {
-  addLevelToMusicMeta,
+  addDataToMusicMeta,
   filterMusicMeta,
   useCachedData,
   useMusicMeta,
@@ -106,7 +106,7 @@ const MusicMeta = () => {
       align: "center",
     },
     {
-      field: "tap_count",
+      field: "note_count",
       headerName: t("music:noteCount"),
       width: 110,
       align: "center",
@@ -140,8 +140,8 @@ const MusicMeta = () => {
   useEffect(() => {
     if (metas && musics && musicDifficulties) {
       const filteredMetas = filterMusicMeta(metas, musics);
-      setValidMetas(addLevelToMusicMeta(filteredMetas, musicDifficulties));
-      setValidMetasCache(addLevelToMusicMeta(filteredMetas, musicDifficulties));
+      setValidMetas(addDataToMusicMeta(filteredMetas, musicDifficulties));
+      setValidMetasCache(addDataToMusicMeta(filteredMetas, musicDifficulties));
     }
   }, [metas, musicDifficulties, musics]);
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -314,7 +314,7 @@ export function filterMusicMeta(metas: IMusicMeta[], musics: IMusicInfo[]) {
   return metas.filter((meta) => validIds.includes(meta.music_id));
 }
 
-export function addLevelToMusicMeta(
+export function addDataToMusicMeta(
   metas: IMusicMeta[],
   musicDifficulties: IMusicDifficultyInfo[]
 ) {
@@ -329,6 +329,7 @@ export function addLevelToMusicMeta(
       return {
         ...meta,
         level: music.playLevel,
+        note_count: music.totalNoteCount,
       };
     }
     return meta;


### PR DESCRIPTION
## Description
Fix note count to display the actual note count instead of tap count.

## Related Issue
Fixes #533

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
