### PR TITLE
fix(music meta): correctly filter out unreleased difficulties

### DIFF
--- a/src/pages/EventPointCalc.tsx
+++ b/src/pages/EventPointCalc.tsx
@@ -35,6 +35,7 @@ import {
   IEventInfo,
   IEventRarityBonusRate,
   IGameCharaUnit,
+  IMusicDifficultyInfo,
   IMusicInfo,
   IMusicMeta,
   ISkillInfo,
@@ -67,6 +68,8 @@ const EventPointCalc: React.FC<unknown> = () => {
   const [cards] = useCachedData<ICardInfo>("cards");
   const [skills] = useCachedData<ISkillInfo>("skills");
   const [musics] = useCachedData<IMusicInfo>("musics");
+  const [musicDifficulties] =
+    useCachedData<IMusicDifficultyInfo>("musicDifficulties");
   const [events] = useCachedData<IEventInfo>("events");
   const [eventCards] = useCachedData<IEventCard>("eventCards");
   const [eventDeckBonuses] = useCachedData<IEventDeckBonus>("eventDeckBonuses");
@@ -145,8 +148,10 @@ const EventPointCalc: React.FC<unknown> = () => {
   }, [teamTotalPower]);
 
   useEffect(() => {
-    if (metas && musics) setValidMetas(filterMusicMeta(metas, musics));
-  }, [metas, musics]);
+    if (metas && musicDifficulties) {
+      setValidMetas(filterMusicMeta(metas, musicDifficulties));
+    }
+  }, [metas, musicDifficulties]);
 
   useEffect(() => {
     if (currEvent && !selectedEvent) {

--- a/src/pages/MusicRecommend.tsx
+++ b/src/pages/MusicRecommend.tsx
@@ -92,11 +92,11 @@ const MusicRecommend: React.FC<unknown> = () => {
   }, [t]);
 
   useEffect(() => {
-    if (metas && musics && musicDifficulties) {
-      const filteredMetas = filterMusicMeta(metas, musics);
+    if (metas && musicDifficulties) {
+      const filteredMetas = filterMusicMeta(metas, musicDifficulties);
       setValidMetas(addDataToMusicMeta(filteredMetas, musicDifficulties));
     }
-  }, [metas, musicDifficulties, musics]);
+  }, [metas, musicDifficulties]);
 
   const columns: GridColDef[] = useMemo(
     () => [

--- a/src/pages/music/MusicMeta.tsx
+++ b/src/pages/music/MusicMeta.tsx
@@ -56,7 +56,7 @@ const MusicMeta = () => {
     {
       field: "music_id",
       headerName: t("common:id"),
-      width: 90,
+      width: 100,
       renderCell(params) {
         return (
           <LinkNoDecoration to={`/music/${params.value}`} target="_blank">

--- a/src/pages/music/MusicMeta.tsx
+++ b/src/pages/music/MusicMeta.tsx
@@ -138,12 +138,12 @@ const MusicMeta = () => {
   ];
 
   useEffect(() => {
-    if (metas && musics && musicDifficulties) {
-      const filteredMetas = filterMusicMeta(metas, musics);
+    if (metas && musicDifficulties) {
+      const filteredMetas = filterMusicMeta(metas, musicDifficulties);
       setValidMetas(addDataToMusicMeta(filteredMetas, musicDifficulties));
       setValidMetasCache(addDataToMusicMeta(filteredMetas, musicDifficulties));
     }
-  }, [metas, musicDifficulties, musics]);
+  }, [metas, musicDifficulties]);
 
   const filterBySongName = () => {
     if (searchTitle && musics?.length) {

--- a/src/pages/music/MusicMeta.tsx
+++ b/src/pages/music/MusicMeta.tsx
@@ -72,6 +72,7 @@ const MusicMeta = () => {
       field: "music_name",
       headerName: t("music_recommend:result.musicName"),
       width: 300,
+      sortable: false,
       renderCell(params) {
         return (
           <ContentTrans

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -308,10 +308,17 @@ export function useMusicMeta() {
   return [data];
 }
 
-export function filterMusicMeta(metas: IMusicMeta[], musics: IMusicInfo[]) {
-  const validIds = musics.map((music) => music.id);
-
-  return metas.filter((meta) => validIds.includes(meta.music_id));
+export function filterMusicMeta(
+  metas: IMusicMeta[],
+  musicDifficulties: IMusicDifficultyInfo[]
+) {
+  return metas.filter((meta) =>
+    musicDifficulties.some(
+      (music) =>
+        music.musicId === meta.music_id &&
+        music.musicDifficulty === meta.difficulty
+    )
+  );
 }
 
 export function addDataToMusicMeta(
@@ -322,8 +329,7 @@ export function addDataToMusicMeta(
     const music = musicDifficulties.find(
       (music) =>
         music.musicId === meta.music_id &&
-        music.musicDifficulty ===
-          (meta.difficulty === "append" ? "master" : meta.difficulty)
+        music.musicDifficulty === meta.difficulty
     );
     if (music) {
       return {


### PR DESCRIPTION
## Description
1. Correctly filter out unreleased difficulties from music meta for each server.
2. Widen the default width for the music id field so the link button still shows when the id is longer than 2 digits.
3. Make the music name row unsortable since it doesn't work

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
