### PR TITLE
fix(l2d): missing argument in PlayScenarioEffect.ts

### DIFF
--- a/src/utils/Live2DPlayer/action/special_effect/PlayScenarioEffect.ts
+++ b/src/utils/Live2DPlayer/action/special_effect/PlayScenarioEffect.ts
@@ -14,5 +14,8 @@ export default async function PlayScenarioEffect(
     action,
     action_detail
   );
-  controller.layers.scene_effect.draw(action_detail.StringVal);
+  controller.layers.scene_effect.draw(
+    action_detail.StringVal,
+    controller.events
+  );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
draw() are expecting emitter.
https://github.com/Sekai-World/sekai-viewer/blob/fb81b5824400e5866816857b8e9ad9f9517992c8/src/utils/Live2DPlayer/layer/SceneEffect.ts#L25
But only effect are provided.
https://github.com/Sekai-World/sekai-viewer/blob/fb81b5824400e5866816857b8e9ad9f9517992c8/src/utils/Live2DPlayer/action/special_effect/PlayScenarioEffect.ts#L17
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [ ] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [x] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/3ac8be99-8a62-4d82-b1a7-ad9033cd4b2a)
