### PR TITLE
fix: wrong URL for voice

### DIFF
--- a/src/utils/storyLoader.ts
+++ b/src/utils/storyLoader.ts
@@ -270,32 +270,6 @@ export function useProcessedScenarioDataForText() {
 
   const getCharaName = useCharaName();
 
-  /**
-   * fix eventStory asset "ScenarioId" field error
-   *
-   * event 168 => event_167_??
-   *
-   * event 169 => event_168_??
-   */
-  const fixVoiceScenarioId = (info: IScenarioInfo, data: IScenarioData) => {
-    if (info.storyType !== "eventStory") {
-      return;
-    }
-
-    const confirmScenarioId = info.scenarioDataUrl.split("/").pop();
-    if (typeof confirmScenarioId !== "string") {
-      return;
-    }
-
-    const isErrored = ["event_168", "event_169"].some((item) =>
-      confirmScenarioId.startsWith(item)
-    );
-
-    if (isErrored) {
-      data.ScenarioId = confirmScenarioId.replace(".asset", "");
-    }
-  };
-
   return useCallback(
     async (info: IScenarioInfo) => {
       const ret: {
@@ -319,8 +293,6 @@ export function useProcessedScenarioDataForText() {
           responseType: "json",
         }
       );
-
-      fixVoiceScenarioId(info, data);
 
       const {
         ScenarioId,
@@ -914,6 +886,17 @@ function modelNameFix(info: IScenarioInfo, data: IScenarioData) {
  * rules see "map".
  */
 function scenarioIdToAssetbundleName(scenarioId: string) {
+  let result = scenarioId;
+
+  // Handle event number offset: if contains "event_" and number > 166, increment by 1
+  const eventMatch = result.match(/event_(\d+)/);
+  if (eventMatch) {
+    const eventNumber = parseInt(eventMatch[1]);
+    if (eventNumber > 166) {
+      result = result.replace(/event_(\d+)/, `event_${eventNumber + 1}`);
+    }
+  }
+
   const map: Record<string, string> = {
     "areatalk03_266(20230607修正)": "areatalk03_266",
     "★4冬弥・泉_前半": "012043_touya01",
@@ -928,5 +911,6 @@ function scenarioIdToAssetbundleName(scenarioId: string) {
     story_connect_live_thanksgiving_4th_anv:
       "story_connect_live_4th_anniversary_01",
   };
-  return map[scenarioId] || scenarioId;
+
+  return map[result] || result;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The AssetbundleName for the voice of event story is constructed from eventId, but not from scenarioId. So, all scenarioId will be increment by 1 starting from event 166 (a testing event). Also, change in #600 is discard to prevent double adding (and it only apply to event 168 and 169 and not apply to live2d story). This is just a temporary solution, a better solution will be truly constructed AssetbundleName from eventId.  
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link @to the issue here: -->
#596
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [x] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
