### PR TITLE
fix: correctly display master lesson cost and reward

### DIFF
--- a/src/components/widgets/Costume3DThumbnail.tsx
+++ b/src/components/widgets/Costume3DThumbnail.tsx
@@ -3,9 +3,9 @@ import { ICompactCostume3DModel, ICostume3DModel } from "../../types";
 import { getRemoteAssetURL, useCachedData, useCompactData } from "../../utils";
 import Image from "mui-image";
 
-type Props = { costumeId: number };
+type Props = { costumeId: number; unit: string };
 
-const Costume3DThumbnail = ({ costumeId }: Props) => {
+const Costume3DThumbnail = ({ costumeId, unit }: Props) => {
   const [costume3dModels] = useCachedData<ICostume3DModel>("costume3dModels");
   const [compactCostume3dModels] = useCompactData<ICompactCostume3DModel>(
     "compactCostume3dModels"
@@ -28,11 +28,16 @@ const Costume3DThumbnail = ({ costumeId }: Props) => {
         ],
       });
     } else if (costume3dModels) {
-      setCostume(
-        costume3dModels.find((elem) => elem.costume3dId === costumeId)
+      const matchingCostumes = costume3dModels.filter(
+        (elem) => elem.costume3dId === costumeId
       );
+      const unitCostume = matchingCostumes.find((elem) => elem.unit === unit);
+      const piaproCostume = matchingCostumes.find(
+        (elem) => elem.unit === "piapro"
+      );
+      setCostume(unitCostume || piaproCostume || matchingCostumes[0]);
     }
-  }, [compactCostume3dModels, costume3dModels, costumeId]);
+  }, [compactCostume3dModels, costume3dModels, costumeId, unit]);
 
   useEffect(() => {
     if (costume) {

--- a/src/components/widgets/ResourceBox.tsx
+++ b/src/components/widgets/ResourceBox.tsx
@@ -21,11 +21,13 @@ const ResourceBox: React.FC<{
   resourceBoxPurpose: string;
   justifyContent?: string;
   materialJustifyContent?: string;
+  unit?: string;
 }> = ({
   resourceBoxId,
   resourceBoxPurpose,
   justifyContent = "space-around",
   materialJustifyContent = "center",
+  unit = "piapro",
 }) => {
   const { region } = useRootStore();
 
@@ -145,7 +147,7 @@ const ResourceBox: React.FC<{
                 key={detail.resourceId}
               />
             ) : detail.resourceType === "costume_3d" ? (
-              <Costume3DThumbnail costumeId={detail.resourceId!} />
+              <Costume3DThumbnail costumeId={detail.resourceId!} unit={unit} />
             ) : detail.resourceType !== "honor" ? (
               <CommonMaterialIcon
                 materialName={detail.resourceType}

--- a/src/pages/card/CardDetail.tsx
+++ b/src/pages/card/CardDetail.tsx
@@ -1489,9 +1489,28 @@ const CardDetail: React.FC<unknown> = observer(() => {
                   </Typography>
                 </Grid>
                 <Grid item xs={9} container justifyContent="flex-end">
-                  {masterLessons
-                    .find((ml) => ml.masterRank === masterRank)!
-                    .costs.map((c, idx) => (
+                  {(() => {
+                    const masterLesson = masterLessons.find(
+                      (ml) => ml.masterRank === masterRank
+                    );
+                    if (!masterLesson) return null;
+
+                    const filteredCosts = masterLesson.costs.filter((cost) => {
+                      if (
+                        cost.unit &&
+                        cost.unit !== card.supportUnit &&
+                        cost.unit !== getCharaUnitName(card.characterId)
+                      )
+                        return false;
+                      if (
+                        cost.characterId &&
+                        cost.characterId !== card.characterId
+                      )
+                        return false;
+                      return true;
+                    });
+
+                    return filteredCosts.map((c, idx) => (
                       <Grid key={`master-rank-cost-${idx}`} item>
                         <MaterialIcon
                           materialId={c.resourceId}
@@ -1499,7 +1518,8 @@ const CardDetail: React.FC<unknown> = observer(() => {
                           justify="center"
                         />
                       </Grid>
-                    ))}
+                    ));
+                  })()}
                 </Grid>
               </Grid>
               <Divider style={{ margin: "1% 0" }} />
@@ -1528,6 +1548,11 @@ const CardDetail: React.FC<unknown> = observer(() => {
                         masterLessonRewards.find(
                           (mlr) => mlr.masterRank === masterRank
                         )!.resourceBoxId
+                      }
+                      unit={
+                        card.supportUnit !== "none"
+                          ? card.supportUnit
+                          : getCharaUnitName(card.characterId)
                       }
                       resourceBoxPurpose="master_lesson_reward"
                       justifyContent="flex-end"

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -92,6 +92,8 @@ export interface Cost {
   resourceType: string;
   resourceLevel?: number;
   quantity: number;
+  unit?: string;
+  characterId?: number;
 }
 
 export interface CardParameter {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

  ### Costume Display Enhancements
  **Enhanced Costume3DThumbnail component** with unit-aware selection logic implementing a double fallback system: prioritize specified unit, then "piapro", then first available costume. 

  ### Master Lesson Cost Filtering
  **Enhanced type definitions** by adding optional `unit` and `characterId` fields to `Cost`  interfaces for better filtering support. 
**Improved CardDetail master lesson cost display** with filtering on unit and character.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#587 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [ ] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [x] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
