### PR TITLE
Gacha simulator guarantee mechanism fix

### DIFF
--- a/src/pages/gacha/GachaDetail.tsx
+++ b/src/pages/gacha/GachaDetail.tsx
@@ -164,11 +164,14 @@ const GachaDetailPage: React.FC<unknown> = observer(() => {
       );
       const tmpGachaResult: GachaDetail[] = [];
       const isOverRarity = behavior.gachaBehaviorType.startsWith("over_rarity");
-      // const overRarity = isOverRarity
-      //   ? behavior.gachaBehaviorType === "over_rarity_3_once"
-      //     ? 3
-      //     : 4
-      //   : 0;
+      let overRarityLevel = 0;
+      if (isOverRarity) {
+        if (behavior.gachaBehaviorType === "over_rarity_3_once") {
+          overRarityLevel = 3;
+        } else if (behavior.gachaBehaviorType === "over_rarity_4_once") {
+          overRarityLevel = 4;
+        }
+      }
       let noOverRarityCount = 0;
       for (let i = 0; i < rollTimes; i++) {
         // console.log(i, rollTimes);
@@ -210,7 +213,8 @@ const GachaDetailPage: React.FC<unknown> = observer(() => {
 
         if (
           isOverRarity &&
-          cardRarityTypeToRarity[gachaRarityRates[idx].cardRarityType] < 3
+          cardRarityTypeToRarity[gachaRarityRates[idx].cardRarityType] <
+            overRarityLevel
         )
           noOverRarityCount += 1;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Update noOverRarityCount to use overRarityLevel based on gacha behavior.
Ensures 4-star member guarantee triggers correctly even if 3-star member appears in prior draws.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Sekai-World/sekai-viewer/issues/635
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an issue where 4-star member guarantees could fail if a 3-star member appeared in prior draws.
## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [x] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
