### PR TITLE
Add show ui button for live2d story reader

### DIFF
--- a/src/pages/storyreader-live2d/StoryReaderLive2DCanvas.tsx
+++ b/src/pages/storyreader-live2d/StoryReaderLive2DCanvas.tsx
@@ -131,6 +131,10 @@ const StoryReaderLive2DCanvas: React.FC<{
       }),
     [settings.seVolume]
   );
+  useEffect(
+    () => stage.current?.controller.show_ui(settings.showUI),
+    [settings.showUI]
+  );
   useEffect(() => {
     if (stage.current)
       stage.current.controller.settings.text_animation = settings.textAnimation;

--- a/src/pages/storyreader-live2d/StoryReaderLive2DContent.tsx
+++ b/src/pages/storyreader-live2d/StoryReaderLive2DContent.tsx
@@ -61,6 +61,7 @@ const StoryReaderLive2DContent: React.FC<{
     autoplay: false,
     textAnimation: true,
     showWarning: true,
+    showUI: true,
   });
   const [showSettings, setShowSettings] = useState(false);
   const [isRegeneratingTranslation, setIsRegeneratingTranslation] =

--- a/src/pages/storyreader-live2d/StoryReaderLive2DSettings.tsx
+++ b/src/pages/storyreader-live2d/StoryReaderLive2DSettings.tsx
@@ -58,6 +58,12 @@ const StoryReaderLive2DSettings: React.FC<{
     },
     [settings]
   );
+  const handleShowUIChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onSettingsChange({ ...settings, showUI: event.target.checked });
+    },
+    [settings]
+  );
 
   return (
     <PaperContainer>
@@ -96,6 +102,24 @@ const StoryReaderLive2DSettings: React.FC<{
                   />
                 }
                 label={t("story_reader_live2d:settings.text_animation")}
+              />
+            </Stack>
+          </Grid>
+          <Grid item xs={12} sm={6} md={6} lg={4} xl={3}>
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="center"
+              sx={{ height: 1, padding: 1 }}
+            >
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={settings.showUI}
+                    onChange={handleShowUIChange}
+                  />
+                }
+                label={t("story_reader_live2d:settings.showUI")}
               />
             </Stack>
           </Grid>

--- a/src/utils/Live2DPlayer/Live2DController.ts
+++ b/src/utils/Live2DPlayer/Live2DController.ts
@@ -436,6 +436,10 @@ export class Live2DController extends Live2DPlayer {
           sound.data.volume(this.settings.se_volume);
         });
   };
+  show_ui = (show = true) => {
+    if (show) this.UIRoot.alpha = 1;
+    else this.UIRoot.alpha = 0;
+  };
   stop_sounds = (sound_types: Live2DAssetType[], unload = false) => {
     this.scenarioResource.audio
       .filter((resource) => sound_types.includes(resource.type))

--- a/src/utils/Live2DPlayer/types.d.ts
+++ b/src/utils/Live2DPlayer/types.d.ts
@@ -197,6 +197,7 @@ export interface ILive2DPlayerSettings {
   autoplay: boolean;
   textAnimation: boolean;
   showWarning: boolean;
+  showUI: boolean;
 }
 
 export enum LoadStatus {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add show ui button to settings, can hide/show ui for screenshot in live2d story reader

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please ensure your code is running good at least on following platform. -->
<!--- To test on mobile device, make sure they are connected to the same WiFi -->
<!--- with your developement machine. -->
<!--- If you can't test Safari browser, you can ignore them. -->

- [x] Chrome (Desktop)
- [x] Chrome (Mobile)
- [x] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Screenshots (if appropriate):
