### PR TITLE
fix: clamp skill level to prevent out-of-bounds crash in music recommender

### DIFF
--- a/src/utils/scoreCalc.ts
+++ b/src/utils/scoreCalc.ts
@@ -32,9 +32,26 @@ export function useScoreCalc() {
       const scoreSkill = skill.skillEffects.filter((it) =>
         it.skillEffectType.includes("score_up")
       )[0];
+
+      // Guard: if no score_up skill found, return 0
+      if (!scoreSkill) {
+        return 0;
+      }
+
+      // Guard: if no skill effect details, return 0
+      if (!scoreSkill.skillEffectDetails || scoreSkill.skillEffectDetails.length === 0) {
+        return 0;
+      }
+
+      // Guard: handle non-numeric skill levels
+      const skillLevel = Number(teamCard.skillLevel);
+      if (!Number.isFinite(skillLevel)) {
+        return 0;
+      }
+
       // Clamp skillLevel to valid range (1 to max available skill levels)
       const maxSkillLevel = scoreSkill.skillEffectDetails.length;
-      const clampedSkillLevel = Math.max(1, Math.min(teamCard.skillLevel, maxSkillLevel));
+      const clampedSkillLevel = Math.max(1, Math.min(skillLevel, maxSkillLevel));
       return (
         scoreSkill.skillEffectDetails[clampedSkillLevel - 1]
           .activateEffectValue / 100

--- a/src/utils/scoreCalc.ts
+++ b/src/utils/scoreCalc.ts
@@ -32,8 +32,11 @@ export function useScoreCalc() {
       const scoreSkill = skill.skillEffects.filter((it) =>
         it.skillEffectType.includes("score_up")
       )[0];
+      // Clamp skillLevel to valid range (1 to max available skill levels)
+      const maxSkillLevel = scoreSkill.skillEffectDetails.length;
+      const clampedSkillLevel = Math.max(1, Math.min(teamCard.skillLevel, maxSkillLevel));
       return (
-        scoreSkill.skillEffectDetails[teamCard.skillLevel - 1]
+        scoreSkill.skillEffectDetails[clampedSkillLevel - 1]
           .activateEffectValue / 100
       );
     },

--- a/src/utils/scoreCalc.ts
+++ b/src/utils/scoreCalc.ts
@@ -26,35 +26,29 @@ const boostRate: Record<number, number> = {
 export function useScoreCalc() {
   const getCardSkillRate = useCallback(
     (cards: ICardInfo[], skills: ISkillInfo[], teamCard: ISekaiCardState) => {
-      const skillId = cards.filter((it) => it.id === teamCard.cardId)[0]
-        .skillId;
-      const skill = skills.filter((it) => it.id === skillId)[0];
-      const scoreSkill = skill.skillEffects.filter((it) =>
+      const card = cards.find((it) => it.id === teamCard.cardId);
+      if (!card) return 0;
+
+      const skill = skills.find((it) => it.id === card.skillId);
+      if (!skill) return 0;
+
+      const scoreSkill = skill.skillEffects.find((it) =>
         it.skillEffectType.includes("score_up")
-      )[0];
+      );
+      if (!scoreSkill) return 0;
 
-      // Guard: if no score_up skill found, return 0
-      if (!scoreSkill) {
-        return 0;
-      }
+      const { skillEffectDetails } = scoreSkill;
+      if (!skillEffectDetails?.length) return 0;
 
-      // Guard: if no skill effect details, return 0
-      if (!scoreSkill.skillEffectDetails || scoreSkill.skillEffectDetails.length === 0) {
-        return 0;
-      }
+      const skillLevel = Math.trunc(Number(teamCard.skillLevel));
+      if (!Number.isFinite(skillLevel)) return 0;
 
-      // Guard: handle non-numeric skill levels
-      const skillLevel = Number(teamCard.skillLevel);
-      if (!Number.isFinite(skillLevel)) {
-        return 0;
-      }
-
-      // Clamp skillLevel to valid range (1 to max available skill levels)
-      const maxSkillLevel = scoreSkill.skillEffectDetails.length;
-      const clampedSkillLevel = Math.max(1, Math.min(skillLevel, maxSkillLevel));
+      const clampedSkillLevel = Math.max(
+        1,
+        Math.min(skillLevel, skillEffectDetails.length)
+      );
       return (
-        scoreSkill.skillEffectDetails[clampedSkillLevel - 1]
-          .activateEffectValue / 100
+        skillEffectDetails[clampedSkillLevel - 1].activateEffectValue / 100
       );
     },
     []


### PR DESCRIPTION
The music recommender crashes with a TypeError when a user's skill level exceeds the length of the difficulty rating array. The code indexes directly into the array without bounds checking.

This clamps the skill level to the valid range before array access, preventing the crash while preserving the recommendation logic for valid inputs.

Fixes #624