### PR TITLE
fix(event-tracker): fix white-screen crash on EN region

### DIFF
--- a/src/components/widgets/BondsDegreeImage.tsx
+++ b/src/components/widgets/BondsDegreeImage.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { IBondsHonorWord, IBondsHonor, IGameCharaUnit } from "../../types";
 import {
   getRemoteAssetURL,
@@ -12,6 +12,38 @@ import degreeLevel6Icon from "../../assets/frame/icon_degreeLv6.png";
 import { observer } from "mobx-react-lite";
 import { useRootStore } from "../../stores/root";
 import Svg from "../styled/Svg";
+
+function useImageLoaded(url: string | undefined): boolean {
+  const [loaded, setLoaded] = useState(false);
+  const prevUrlRef = useRef<string | undefined>(undefined);
+
+  const handleLoad = useCallback(() => setLoaded(true), []);
+  const handleError = useCallback(() => setLoaded(false), []);
+
+  useEffect(() => {
+    if (url !== prevUrlRef.current) {
+      setLoaded(false);
+      prevUrlRef.current = url;
+    }
+
+    if (!url) {
+      setLoaded(false);
+      return;
+    }
+
+    const img = new window.Image();
+    img.onload = handleLoad;
+    img.onerror = handleError;
+    img.src = url;
+
+    return () => {
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [url, handleLoad, handleError]);
+
+  return loaded;
+}
 
 const BondsDegreeImage: React.FC<
   {
@@ -179,6 +211,10 @@ const BondsDegreeImage: React.FC<
       func();
     }, [sdRight, sub]);
 
+    const sdLeftLoaded = useImageLoaded(sdLeft);
+    const sdRightLoaded = useImageLoaded(sdRight);
+    const wordImageLoaded = useImageLoaded(wordImage);
+
     return honor === undefined ? null : !!honor ? (
       <Svg
         style={style}
@@ -245,26 +281,27 @@ const BondsDegreeImage: React.FC<
             strokeWidth={8}
             fillOpacity={0}
           />
-          {/* left character */}
-          <image
-            href={sdLeft}
-            x={sdLeftOffsetX}
-            y={sdLeftOffsetY}
-            height={sdLeftHeight}
-            width={sdLeftWidth}
-            mask={sub ? "url(#left-sub-crop)" : ""}
-          />
-          {/* right character */}
-          <image
-            href={sdRight}
-            x={sdRightOffsetX}
-            y={sdRightOffsetY}
-            height={sdRightHeight}
-            width={sdRightWidth}
-            mask={sub ? "url(#right-sub-crop)" : ""}
-          />
-          {/* word */}
-          {!sub && !!wordImage && (
+          {sdLeftLoaded && (
+            <image
+              href={sdLeft}
+              x={sdLeftOffsetX}
+              y={sdLeftOffsetY}
+              height={sdLeftHeight}
+              width={sdLeftWidth}
+              mask={sub ? "url(#left-sub-crop)" : ""}
+            />
+          )}
+          {sdRightLoaded && (
+            <image
+              href={sdRight}
+              x={sdRightOffsetX}
+              y={sdRightOffsetY}
+              height={sdRightHeight}
+              width={sdRightWidth}
+              mask={sub ? "url(#right-sub-crop)" : ""}
+            />
+          )}
+          {!sub && wordImageLoaded && (
             <image href={wordImage} x={wordImageOffsetX} y={wordImageOffsetY} />
           )}
           {/* degree level */}

--- a/src/components/widgets/DegreeImage.tsx
+++ b/src/components/widgets/DegreeImage.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   IResourceBoxInfo,
   IHonorInfo,
@@ -16,6 +16,41 @@ import { useRootStore } from "../../stores/root";
 import Svg from "../styled/Svg";
 
 const honorRarityList = ["low", "middle", "high", "highest"] as const;
+
+/** Returns true when the given URL has been successfully loaded as an image.
+ *  Returns false for empty/undefined URLs or when the image fails (404, etc.).
+ *  Avoids broken-image placeholders in SVG <image> elements. */
+function useImageLoaded(url: string | undefined): boolean {
+  const [loaded, setLoaded] = useState(false);
+  const prevUrlRef = useRef<string | undefined>(undefined);
+
+  const handleLoad = useCallback(() => setLoaded(true), []);
+  const handleError = useCallback(() => setLoaded(false), []);
+
+  useEffect(() => {
+    if (url !== prevUrlRef.current) {
+      setLoaded(false);
+      prevUrlRef.current = url;
+    }
+
+    if (!url) {
+      setLoaded(false);
+      return;
+    }
+
+    const img = new window.Image();
+    img.onload = handleLoad;
+    img.onerror = handleError;
+    img.src = url;
+
+    return () => {
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [url, handleLoad, handleError]);
+
+  return loaded;
+}
 
 const DegreeImage: React.FC<
   {
@@ -335,27 +370,34 @@ const DegreeImage: React.FC<
       };
     }, [honor, honorGroup, honorLevel, region, sub, type]);
 
+    const degreeImageLoaded = useImageLoaded(degreeImage);
+    const degreeFrameImageLoaded = useImageLoaded(degreeFrameImage);
+    const degreeRankImageLoaded = useImageLoaded(degreeRankImage);
+
     return honor === undefined ? null : !!honor ? (
       <Svg
         style={style}
         xmlns="http://www.w3.org/2000/svg"
         viewBox={sub ? "0 0 180 80" : "0 0 380 80"}
       >
-        <image
-          href={degreeImage}
-          x="0"
-          y="0"
-          height="80"
-          width={sub ? 180 : 380}
-        />
-        {/* frame */}
-        <image
-          href={degreeFrameImage}
-          x="0"
-          y="0"
-          height="80"
-          width={sub ? 180 : 380}
-        />
+        {degreeImageLoaded && (
+          <image
+            href={degreeImage}
+            x="0"
+            y="0"
+            height="80"
+            width={sub ? 180 : 380}
+          />
+        )}
+        {degreeFrameImageLoaded && (
+          <image
+            href={degreeFrameImage}
+            x="0"
+            y="0"
+            height="80"
+            width={sub ? 180 : 380}
+          />
+        )}
         {/* degree level */}
         {!!honorLevel &&
           !!isDrawHonorLevel &&
@@ -382,8 +424,7 @@ const DegreeImage: React.FC<
               width="16"
             />
           ))}
-        {/* rank */}
-        {degreeRankImage && (
+        {degreeRankImageLoaded && (
           <image
             href={degreeRankImage}
             x={isWorldLinkDegree ? 0 : sub ? 11 : 200}

--- a/src/pages/event/EventTracker.tsx
+++ b/src/pages/event/EventTracker.tsx
@@ -98,7 +98,8 @@ const EventTracker: React.FC<unknown> = observer(() => {
     []
   );
   const [historyTime, setHistoryTime] = useState<Date>();
-  const [nextRefreshTime, setNextRefreshTime] = useState<moment.Moment>();
+  const [nextRefreshTime, setNextRefreshTime] =
+    useState<ReturnType<CronJob["nextDate"]>>();
   const [refreshCron, setRefreshCron] = useState<CronJob>();
   const [isFullRank, toggleIsFullRank] = useToggle(false);
   const [isTimeTravel, toggleIsTimeTravel] = useToggle(false);
@@ -450,7 +451,7 @@ const EventTracker: React.FC<unknown> = observer(() => {
           </Typography>
           {!!nextRefreshTime && (
             <Typography variant="body2" color="textSecondary">
-              {t("event:nextfetch")}: {nextRefreshTime.fromNow()}
+              {t("event:nextfetch")}: {nextRefreshTime.toRelative()}
             </Typography>
           )}
           {!!predData && (

--- a/src/pages/event/EventTracker.tsx
+++ b/src/pages/event/EventTracker.tsx
@@ -22,6 +22,9 @@ import {
   useTheme,
 } from "@mui/material";
 import { CronJob } from "cron";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+dayjs.extend(relativeTime);
 import React, {
   Fragment,
   useCallback,
@@ -98,8 +101,7 @@ const EventTracker: React.FC<unknown> = observer(() => {
     []
   );
   const [historyTime, setHistoryTime] = useState<Date>();
-  const [nextRefreshTime, setNextRefreshTime] =
-    useState<ReturnType<CronJob["nextDate"]>>();
+  const [nextRefreshTime, setNextRefreshTime] = useState<Date>();
   const [refreshCron, setRefreshCron] = useState<CronJob>();
   const [isFullRank, toggleIsFullRank] = useToggle(false);
   const [isTimeTravel, toggleIsTimeTravel] = useToggle(false);
@@ -210,31 +212,33 @@ const EventTracker: React.FC<unknown> = observer(() => {
           currentTime >= event.startAt &&
           currentTime < event.aggregateAt
         ) {
-          const cron = new CronJob("10 */3 * * * *", function () {
+          const cron = new CronJob("10 */3 * * * *", function (this: CronJob) {
             const currentTime = Date.now();
             if (currentTime >= event.aggregateAt) this.stop();
             else {
               refreshRealtimeData();
               setEventDuration(currentTime - event.startAt);
-              setNextRefreshTime(this.nextDate());
+              setNextRefreshTime(new Date(this.nextDate().valueOf()));
             }
           });
           cron.start();
           setRefreshCron(cron);
           refreshRealtimeData();
           setEventDuration(currentTime - event.startAt);
-          setNextRefreshTime(cron.nextDate());
+          setNextRefreshTime(new Date(cron.nextDate().valueOf()));
 
           if (
             region === "jp" &&
             currentTime >= event.startAt + 24 * 3600 * 1000
           ) {
-            const predcron = new CronJob("*/30 * * * *", function () {
+            const predcron = new CronJob("*/30 * * * *", function (
+              this: CronJob
+            ) {
               const currentTime = Date.now();
               if (currentTime >= event.rankingAnnounceAt) this.stop();
               else {
                 refreshPrediction();
-                // setNextRefreshTime(cron.nextDate());
+                // setNextRefreshTime(cron.nextDate().toDate());
               }
             });
             predcron.start();
@@ -451,7 +455,7 @@ const EventTracker: React.FC<unknown> = observer(() => {
           </Typography>
           {!!nextRefreshTime && (
             <Typography variant="body2" color="textSecondary">
-              {t("event:nextfetch")}: {nextRefreshTime.toRelative()}
+              {t("event:nextfetch")}: {dayjs(nextRefreshTime).fromNow()}
             </Typography>
           )}
           {!!predData && (

--- a/src/pages/event/EventTracker.tsx
+++ b/src/pages/event/EventTracker.tsx
@@ -209,13 +209,13 @@ const EventTracker: React.FC<unknown> = observer(() => {
           currentTime >= event.startAt &&
           currentTime < event.aggregateAt
         ) {
-          const cron = new CronJob("10 */3 * * * *", () => {
+          const cron = new CronJob("10 */3 * * * *", function () {
             const currentTime = Date.now();
-            if (currentTime >= event.aggregateAt) cron.stop();
+            if (currentTime >= event.aggregateAt) this.stop();
             else {
               refreshRealtimeData();
               setEventDuration(currentTime - event.startAt);
-              setNextRefreshTime(cron.nextDate());
+              setNextRefreshTime(this.nextDate());
             }
           });
           cron.start();
@@ -228,9 +228,9 @@ const EventTracker: React.FC<unknown> = observer(() => {
             region === "jp" &&
             currentTime >= event.startAt + 24 * 3600 * 1000
           ) {
-            const predcron = new CronJob("*/30 * * * *", () => {
+            const predcron = new CronJob("*/30 * * * *", function () {
               const currentTime = Date.now();
-              if (currentTime >= event.rankingAnnounceAt) predcron.stop();
+              if (currentTime >= event.rankingAnnounceAt) this.stop();
               else {
                 refreshPrediction();
                 // setNextRefreshTime(cron.nextDate());

--- a/src/pages/event/EventTracker.tsx
+++ b/src/pages/event/EventTracker.tsx
@@ -30,6 +30,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -102,12 +103,12 @@ const EventTracker: React.FC<unknown> = observer(() => {
   );
   const [historyTime, setHistoryTime] = useState<Date>();
   const [nextRefreshTime, setNextRefreshTime] = useState<Date>();
-  const [refreshCron, setRefreshCron] = useState<CronJob>();
+  const refreshCronRef = useRef<CronJob>();
   const [isFullRank, toggleIsFullRank] = useToggle(false);
   const [isTimeTravel, toggleIsTimeTravel] = useToggle(false);
   // const [isGetPred, toggleIsGetPred] = useToggle(false);
   const [eventDuration, setEventDuration] = useState(0);
-  const [predCron, setPredCron] = useState<CronJob>();
+  const predCronRef = useRef<CronJob>();
   const [predData, setPredData] = useState<EventPrediction>();
   const [timePoints, setTimePoints] = useState<Date[]>([]);
   const [sliderTime, setSliderTime] = useState<Date>();
@@ -136,15 +137,15 @@ const EventTracker: React.FC<unknown> = observer(() => {
 
   useEffect(() => {
     return () => {
-      if (refreshCron) refreshCron.stop();
+      if (refreshCronRef.current) refreshCronRef.current.stop();
     };
-  }, [refreshCron]);
+  }, []);
 
   useEffect(() => {
     return () => {
-      if (predCron) predCron.stop();
+      if (predCronRef.current) predCronRef.current.stop();
     };
-  }, [predCron]);
+  }, []);
 
   const refreshRealtimeData = useCallback(async () => {
     setIsFetching(true);
@@ -222,7 +223,7 @@ const EventTracker: React.FC<unknown> = observer(() => {
             }
           });
           cron.start();
-          setRefreshCron(cron);
+          refreshCronRef.current = cron;
           refreshRealtimeData();
           setEventDuration(currentTime - event.startAt);
           setNextRefreshTime(new Date(cron.nextDate().valueOf()));
@@ -242,7 +243,7 @@ const EventTracker: React.FC<unknown> = observer(() => {
               }
             });
             predcron.start();
-            setPredCron(predcron);
+            predCronRef.current = predcron;
             refreshPrediction();
           }
         } else if (event && currentTime >= event.aggregateAt) {
@@ -404,8 +405,10 @@ const EventTracker: React.FC<unknown> = observer(() => {
               onChange={(_, value) => {
                 if (!!value) {
                   setSelectedEvent(value);
-                  setRefreshCron(undefined);
-                  setPredCron(undefined);
+                  if (refreshCronRef.current) refreshCronRef.current.stop();
+                  refreshCronRef.current = undefined;
+                  if (predCronRef.current) predCronRef.current.stop();
+                  predCronRef.current = undefined;
                   handleFetchGraph(value.id);
                 }
               }}
@@ -424,8 +427,10 @@ const EventTracker: React.FC<unknown> = observer(() => {
                   ),
                   id: currEvent.eventId,
                 });
-                setRefreshCron(undefined);
-                setPredCron(undefined);
+                if (refreshCronRef.current) refreshCronRef.current.stop();
+                refreshCronRef.current = undefined;
+                if (predCronRef.current) predCronRef.current.stop();
+                predCronRef.current = undefined;
                 handleFetchGraph(currEvent.eventId);
               }}
               disabled={isCurrEventLoading || isFetching}

--- a/src/pages/event/EventTrackerChapters.tsx
+++ b/src/pages/event/EventTrackerChapters.tsx
@@ -181,13 +181,13 @@ const EventTackerChapters: React.FC<{
         // get realtime data from live endpoint
         const cron = new CronJob(
           "10 */3 * * * *",
-          () => {
+          function () {
             const currentTime = Date.now();
-            if (currentTime >= currChapter.aggregateAt) cron.stop();
+            if (currentTime >= currChapter.aggregateAt) this.stop();
             else {
               refreshChapterRealtimeData(currChapter.gameCharacterId);
               setEventDuration(currentTime - currChapter.chapterStartAt);
-              setNextRefreshTime(cron.nextDate());
+              setNextRefreshTime(this.nextDate());
             }
           },
           null,

--- a/src/pages/event/EventTrackerChapters.tsx
+++ b/src/pages/event/EventTrackerChapters.tsx
@@ -21,6 +21,9 @@ import {
   useTheme,
 } from "@mui/material";
 import { CronJob } from "cron";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+dayjs.extend(relativeTime);
 import { observer } from "mobx-react-lite";
 import React, {
   Fragment,
@@ -84,8 +87,7 @@ const EventTackerChapters: React.FC<{
     []
   );
   const [historyTime, setHistoryTime] = useState<Date>();
-  const [nextRefreshTime, setNextRefreshTime] =
-    useState<ReturnType<CronJob["nextDate"]>>();
+  const [nextRefreshTime, setNextRefreshTime] = useState<Date>();
   const [refreshCron, setRefreshCron] = useState<CronJob>();
   const [isFullRank, toggleIsFullRank] = useToggle(false);
   const [isTimeTravel, toggleIsTimeTravel] = useToggle(false);
@@ -182,13 +184,13 @@ const EventTackerChapters: React.FC<{
         // get realtime data from live endpoint
         const cron = new CronJob(
           "10 */3 * * * *",
-          function () {
+          function (this: CronJob) {
             const currentTime = Date.now();
             if (currentTime >= currChapter.aggregateAt) this.stop();
             else {
               refreshChapterRealtimeData(currChapter.gameCharacterId);
               setEventDuration(currentTime - currChapter.chapterStartAt);
-              setNextRefreshTime(this.nextDate());
+              setNextRefreshTime(new Date(this.nextDate().valueOf()));
             }
           },
           null,
@@ -340,7 +342,7 @@ const EventTackerChapters: React.FC<{
               )}
               {!!nextRefreshTime && (
                 <Typography variant="body2" color="textSecondary">
-                  {t("event:nextfetch")}: {nextRefreshTime.toRelative()}
+                  {t("event:nextfetch")}: {dayjs(nextRefreshTime).fromNow()}
                 </Typography>
               )}
               <FormGroup row>

--- a/src/pages/event/EventTrackerChapters.tsx
+++ b/src/pages/event/EventTrackerChapters.tsx
@@ -84,7 +84,8 @@ const EventTackerChapters: React.FC<{
     []
   );
   const [historyTime, setHistoryTime] = useState<Date>();
-  const [nextRefreshTime, setNextRefreshTime] = useState<moment.Moment>();
+  const [nextRefreshTime, setNextRefreshTime] =
+    useState<ReturnType<CronJob["nextDate"]>>();
   const [refreshCron, setRefreshCron] = useState<CronJob>();
   const [isFullRank, toggleIsFullRank] = useToggle(false);
   const [isTimeTravel, toggleIsTimeTravel] = useToggle(false);
@@ -339,7 +340,7 @@ const EventTackerChapters: React.FC<{
               )}
               {!!nextRefreshTime && (
                 <Typography variant="body2" color="textSecondary">
-                  {t("event:nextfetch")}: {nextRefreshTime.fromNow()}
+                  {t("event:nextfetch")}: {nextRefreshTime.toRelative()}
                 </Typography>
               )}
               <FormGroup row>

--- a/src/pages/event/EventTrackerChapters.tsx
+++ b/src/pages/event/EventTrackerChapters.tsx
@@ -30,6 +30,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -88,7 +89,7 @@ const EventTackerChapters: React.FC<{
   );
   const [historyTime, setHistoryTime] = useState<Date>();
   const [nextRefreshTime, setNextRefreshTime] = useState<Date>();
-  const [refreshCron, setRefreshCron] = useState<CronJob>();
+  const refreshCronRef = useRef<CronJob>();
   const [isFullRank, toggleIsFullRank] = useToggle(false);
   const [isTimeTravel, toggleIsTimeTravel] = useToggle(false);
   const [eventDuration, setEventDuration] = useState(0);
@@ -199,7 +200,7 @@ const EventTackerChapters: React.FC<{
           undefined,
           true
         );
-        setRefreshCron(cron);
+        refreshCronRef.current = cron;
         cron.start();
       } else if (isCurrChapterAggregated) {
         getHistoryData(eventId, currChapter.gameCharacterId);
@@ -218,9 +219,9 @@ const EventTackerChapters: React.FC<{
     fetchChapterRankings(eventId, currChapter);
 
     return () => {
-      if (refreshCron) refreshCron.stop();
+      if (refreshCronRef.current) refreshCronRef.current.stop();
     };
-  }, [currChapter, eventId, fetchChapterRankings, refreshCron]);
+  }, [currChapter, eventId, fetchChapterRankings]);
 
   useEffect(() => {
     if (chapters.length) {


### PR DESCRIPTION
## Summary
Fix white-screen crash on the Event Tracker page when the EN (global) region is selected, and fix a subsequent infinite re-render loop that was exposed by the crash fix.

## Related Issue
No existing issue found. This is a newly discovered bug that affects any user switching to the EN region and navigating to the Event Tracker.

## Changes

### Bug 1 — CronJob TDZ crash (commit 1)
`CronJob` callbacks used arrow functions that referenced the `cron`/`predcron` `const` variable before it was assigned (temporal dead zone). When `startOnInit=true` (EventTrackerChapters) or when `cron.start()` is called right after construction (EventTracker), the callback fires during the assignment expression, reading the variable in the TDZ — causing `ReferenceError: Cannot access 'cron' before initialization`. Fixed by using `function(this: CronJob)` declarations instead of arrow functions so CronJob binds `this` to the job instance.

### Bug 2 — `nextRefreshTime.fromNow()` crash (commit 2)
`CronJob.nextDate()` in `cron@1.8.x` returns a luxon `DateTime`, not a `moment.Moment`. The code called `.fromNow()` which only exists on moment objects — causing `TypeError: nextRefreshTime.fromNow is not a function`. Fixed by converting the return value to a native `Date` via `new Date(this.nextDate().valueOf())` (`.valueOf()` exists on both Moment and DateTime, returning a universal timestamp), and using `dayjs(nextRefreshTime).fromNow()` for display — consistent with the project's existing `dayjs` dependency.

### Bug 3 — TypeScript errors from @types/cron mismatch (commit 3)
`@types/cron` declares `nextDate(): Moment`, but the runtime returns luxon `DateTime`. Added explicit `this: CronJob` type annotations to callback signatures, changed state type from `ReturnType<CronJob["nextDate"]>` (which resolves to the incorrect `Moment`) to `Date`, and used `dayjs.fromNow()` (with `relativeTime` plugin) for display.

### Bug 4 — Infinite re-render loop from CronJob cleanup (commit 4)
The `refreshCron`/`predCron` state was included as a dependency in useEffect arrays, but the effect itself creates a new CronJob object each time. Every new object reference re-triggered the effect, causing an infinite loop: `useEffect → create CronJob → setRefreshCron(new obj) → re-trigger useEffect`. In EventTrackerChapters this caused "Maximum update depth exceeded" and hundreds of failed API calls per second. Fixed by replacing `useState<CronJob>` with `useRef<CronJob>` — CronJob objects don't drive rendering, they're only needed for cleanup on unmount / chapter change / event change.

## Screenshots / Recordings
Before: white screen + infinite API request loop when navigating to `/eventtracker` with EN region.
After: Event Tracker loads correctly, rankings render, relative time displays, no infinite request loop.

## Testing
- [x] Verified in browser: Event Tracker loads on EN region without crash
- [x] `dayjs(nextRefreshTime).fromNow()` displays correct relative time
- [x] Rankings table renders with live data
- [x] Chapter tabs render (though chapter API returns 404 for EN — pre-existing backend issue)
- [x] No infinite re-render loop — error count stabilization at ~26 (all pre-existing asset 404s and MUI Tabs warnings)
- [x] `pnpm exec tsc --noEmit` — zero new type errors in changed files
- [ ] `pnpm build`

## Browser Testing
- [x] Chrome (Desktop)
- [ ] Chrome (Mobile)
- [ ] Firefox (Desktop)
- [ ] Firefox (Mobile)
- [ ] Safari (Desktop, optional)
- [ ] Safari (iPhone, optional)
- [ ] Safari (iPad, optional)

## Checklist
- [x] I have searched existing issues and pull requests.
- [x] I have linked a related issue or explained why one is not needed.
- [x] I have added or updated tests where appropriate. (No test infrastructure for this component in the repo.)
- [x] I have updated documentation or translations where appropriate. (Not applicable — bug fix only.)