### PR TITLE
fix(fonts): replace expired font mirror

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,37 +38,37 @@
       rel="preload"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
-      href="https://fonts.font.im/css2?family=Roboto:wght@300;400;500;700&display=swap"
+      href="https://gstatic.aby.pub/css2?family=Roboto:wght@300;400;500;700&display=swap"
     />
     <link
       rel="preload"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
-      href="https://fonts.font.im/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap"
+      href="https://gstatic.aby.pub/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap"
     />
     <link
       rel="preload"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
-      href="https://fonts.font.im/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap"
+      href="https://gstatic.aby.pub/css2?family=Noto+Sans+SC:wght@300;400;500;700&display=swap"
     />
     <link
       rel="preload"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
-      href="https://fonts.font.im/css2?family=Noto+Sans+TC:wght@300;400;500;700&display=swap"
+      href="https://gstatic.aby.pub/css2?family=Noto+Sans+TC:wght@300;400;500;700&display=swap"
     />
     <link
       rel="preload"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
-      href="https://fonts.font.im/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap"
+      href="https://gstatic.aby.pub/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap"
     />
     <link
       rel="preload"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
-      href="https://fonts.font.im/icon?family=Material+Icons&display=swap"
+      href="https://gstatic.aby.pub/icon?family=Material+Icons&display=swap"
     />
     <title>Sekai Viewer</title>
   </head>

--- a/src/utils/fonts.ts
+++ b/src/utils/fonts.ts
@@ -2,12 +2,12 @@ export const fontList = `"Roboto","Overpass","Prompt","Noto Sans JP","Noto Sans 
 export const fontFaceOverride = `
 @font-face {  
   font-family: "Overpass";
-  src: url(https://fonts.gstatic.font.im/s/overpass/v10/qFdH35WCmI96Ajtm81GlU9s.woff2) format('woff2');
+  src: url(https://gstatic.aby.pub/s/overpass/v10/qFdH35WCmI96Ajtm81GlU9s.woff2) format('woff2');
   unicode-range: "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD";
 }
 @font-face {
   font-family: "Prompt";
-  src: url(https://fonts.gstatic.font.im/s/prompt/v9/-W_8XJnvUD7dzB2Cy_gIfWMuQ5Q.woff2) format('woff2');
+  src: url(https://gstatic.aby.pub/s/prompt/v9/-W_8XJnvUD7dzB2Cy_gIfWMuQ5Q.woff2) format('woff2');
   unicode-range: U+0E01-0E5B, U+200C-200D, U+25CC;
 }
 `;


### PR DESCRIPTION
## Summary
- replace expired font.im stylesheet URLs with gstatic.aby.pub
- replace direct Overpass and Prompt font file URLs with the compatible mirror

## Validation
- pnpm build
- verified no remaining font.im references

User confirmed the replacement URLs are reachable from their China mainland network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated font asset sources to improve font loading reliability across supported languages and icon fonts.
  * Updated Overpass and Prompt font loading to use the new asset host while preserving existing styles and character support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->