### PR TITLE
fix:error with team power count counting not accepting cards without side stories.

### DIFF
--- a/src/components/blocks/TeamBuilder.tsx
+++ b/src/components/blocks/TeamBuilder.tsx
@@ -539,12 +539,12 @@ const TeamBuilder: React.FC<{
           level: userCard.level,
           masterRank: userCard.masterRank,
           skillLevel: 1,
-          story1Unlock: userCard.episodes
-            ? userCard.episodes[0].scenarioStatus !== "unreleased"
-            : false,
-          story2Unlock: userCard.episodes
-            ? userCard.episodes[1].scenarioStatus !== "unreleased"
-            : false,
+          story1Unlock:
+            userCard.episodes?.[0] !== undefined &&
+            userCard.episodes[0].scenarioStatus !== "unreleased",
+          story2Unlock:
+            userCard.episodes?.[1] !== undefined &&
+            userCard.episodes[1].scenarioStatus !== "unreleased",
           trainable,
           trained: trainable && userCard.specialTrainingStatus === "done",
         };


### PR DESCRIPTION
## Summary
fix: changed [1] and [2] in side story declaration to be able to accept cards with no side stories. 

Previously, the script outputs a "TypeScript" error if the card has no side stories due to it expecting side stories whereas some cards such as the **From The Window SEKAI** card does not have any side stories and the team power counting system would refuse to work.

## Related Issue
Issue can be found at [this link](https://github.com/Sekai-World/sekai-viewer/issues/687)

## Changes
Changed the system so that instead of it expecting side stories from the card (episodes variable undefined, only has one entry, etc...) it can safely return "not unlocked" instead of throwing a TypeScript error.

## Screenshots / Recordings
<img width="542" height="263" alt="Screenshot 2026-07-29 221545" src="https://github.com/user-attachments/assets/aa7ebc9c-387f-4bcd-ac9e-17704e901674" /> Before fix

<img width="758" height="538" alt="image" src="https://github.com/user-attachments/assets/837b1cf8-0527-4c50-846b-2492d744c71e" /> After fix

## Testing
<!-- Describe the checks you ran. -->
After fixing the TypeScript code, I went to the browser-complied Javascript **(Firefox)** and changed the fix in there to reflect the changes shown, which the results is shown on top of this section. This TypeScript fix should be able to fix this problem perm.

## Browser Testing
<!-- For mobile testing, use a device on the same network as your dev machine. Safari is optional. -->

- [ ] Firefox (Desktop)

## Checklist

- [] I have searched existing issues and pull requests.
- [ ] I have linked a related issue or explained why one is not needed.
- [ ] I have added or updated tests where appropriate.
- [ ] I have updated documentation or translations where appropriate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved story unlock handling when episode information is unavailable.
  * Stories are now unlocked only when their associated episode exists and has been released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->