### PR TITLE
fix(music): support standalone music categories

### DIFF
--- a/src/pages/EventPointCalc.tsx
+++ b/src/pages/EventPointCalc.tsx
@@ -36,12 +36,16 @@ import {
   IEventRarityBonusRate,
   IGameCharaUnit,
   IMusicDifficultyInfo,
-  IMusicInfo,
   IMusicMeta,
   ISkillInfo,
   // ITeamCardState,
 } from "../types.d";
-import { filterMusicMeta, useCachedData, useMusicMeta } from "../utils";
+import {
+  filterMusicMeta,
+  useCachedData,
+  useMusicMeta,
+  useMusics,
+} from "../utils";
 import { useAssetI18n } from "../utils/i18n";
 import { useDurationI18n } from "../utils/i18nDuration";
 import { useScoreCalc } from "../utils/scoreCalc";
@@ -67,7 +71,7 @@ const EventPointCalc: React.FC<unknown> = () => {
 
   const [cards] = useCachedData<ICardInfo>("cards");
   const [skills] = useCachedData<ISkillInfo>("skills");
-  const [musics] = useCachedData<IMusicInfo>("musics");
+  const [musics] = useMusics();
   const [musicDifficulties] =
     useCachedData<IMusicDifficultyInfo>("musicDifficulties");
   const [events] = useCachedData<IEventInfo>("events");

--- a/src/pages/MusicRecommend.tsx
+++ b/src/pages/MusicRecommend.tsx
@@ -21,7 +21,6 @@ import { useTranslation } from "react-i18next";
 import {
   ICardInfo,
   IMusicDifficultyInfo,
-  IMusicInfo,
   IMusicMeta,
   IMusicRecommendResult,
   ISkillInfo,
@@ -31,6 +30,7 @@ import {
   addDataToMusicMeta,
   filterMusicMeta,
   useCachedData,
+  useMusics,
   useMusicMeta,
 } from "../utils";
 import {
@@ -55,7 +55,7 @@ const MusicRecommend: React.FC<unknown> = () => {
 
   const [cards] = useCachedData<ICardInfo>("cards");
   const [skills] = useCachedData<ISkillInfo>("skills");
-  const [musics] = useCachedData<IMusicInfo>("musics");
+  const [musics] = useMusics();
   const [musicDifficulties] =
     useCachedData<IMusicDifficultyInfo>("musicDifficulties");
   const [metas] = useMusicMeta();

--- a/src/pages/UnitDetail.tsx
+++ b/src/pages/UnitDetail.tsx
@@ -9,7 +9,7 @@ import {
   IMusicTagInfo,
   IUnitProfile,
 } from "../types.d";
-import { getRemoteAssetURL, useCachedData } from "../utils";
+import { getRemoteAssetURL, useCachedData, useMusics } from "../utils";
 import { useAssetI18n, useCharaName } from "../utils/i18n";
 import { charaIcons, UnitLogoMap } from "../utils/resources";
 import ColorPreview from "../components/helpers/ColorPreview";
@@ -56,7 +56,7 @@ const UnitDetail: React.FC<unknown> = observer(() => {
 
   const [unitProfiles] = useCachedData<IUnitProfile>("unitProfiles");
   const [gameCharas] = useCachedData<IGameChara>("gameCharacters");
-  const [musics] = useCachedData<IMusicInfo>("musics");
+  const [musics] = useMusics();
   const [musicTags] = useCachedData<IMusicTagInfo>("musicTags");
 
   const [unit, setUnit] = useState<IUnitProfile>();

--- a/src/pages/card/CardDetail.tsx
+++ b/src/pages/card/CardDetail.tsx
@@ -45,6 +45,7 @@ import {
   // specialTrainingRarityTypes,
   useCachedData,
   useCardType,
+  useMusics,
 } from "../../utils";
 import rarityNormal from "../../assets/rarity_star_normal.png";
 import rarityAfterTraining from "../../assets/rarity_star_afterTraining.png";
@@ -121,7 +122,7 @@ const CardDetail: React.FC<unknown> = observer(() => {
   );
   const [another3dmvCutIns] =
     useCachedData<IAnother3dmvCutIn>("another3dmvCutIns");
-  const [musics] = useCachedData<IMusicInfo>("musics");
+  const [musics] = useMusics();
   const [cardSupplies] = useCachedData<ICardSupply>("cardSupplies");
 
   const { cardId } = useParams<{ cardId: string }>();

--- a/src/pages/music/AgendaView.tsx
+++ b/src/pages/music/AgendaView.tsx
@@ -179,7 +179,7 @@ const AgendaView: React.FC<{ data?: IMusicInfo }> = observer(({ data }) => {
             </Grid>
           </Grid>
           <Grid item xs={12} sm={2}>
-            {data.categories.map((cat) => (
+            {(data.categories ?? []).map((cat) => (
               <Chip
                 label={t(
                   `music:categoryType.${

--- a/src/pages/music/GridView.tsx
+++ b/src/pages/music/GridView.tsx
@@ -80,7 +80,7 @@ const GridView: React.FC<{ data?: IMusicInfo }> = observer(({ data }) => {
           </Grid>
           <Grid item>
             <Typography variant="body2" color="textSecondary">
-              {data.categories
+              {(data.categories ?? [])
                 .map((cat) =>
                   t(
                     `music:categoryType.${

--- a/src/pages/music/MusicDetail.tsx
+++ b/src/pages/music/MusicDetail.tsx
@@ -29,7 +29,12 @@ import {
   IOutCharaProfile,
   IMusicOriginal,
 } from "../../types.d";
-import { getRemoteAssetURL, useCachedData, useMusicTagName } from "../../utils";
+import {
+  getRemoteAssetURL,
+  useCachedData,
+  useMusicTagName,
+  useMusics,
+} from "../../utils";
 import { charaIcons } from "../../utils/resources";
 import { Trans, useTranslation } from "react-i18next";
 import { useAssetI18n, useCharaName } from "../../utils/i18n";
@@ -90,7 +95,7 @@ const MusicDetail: React.FC<unknown> = observer(() => {
   const musicTagToName = useMusicTagName(contentTransMode);
   const { getMusic } = useStrapi();
 
-  const [musics] = useCachedData<IMusicInfo>("musics");
+  const [musics] = useMusics();
   const [musicVocals] = useCachedData<IMusicVocalInfo>("musicVocals");
   const [musicDiffis] =
     useCachedData<IMusicDifficultyInfo>("musicDifficulties");
@@ -574,7 +579,7 @@ const MusicDetail: React.FC<unknown> = observer(() => {
                     label={t("music:vocalTab.title[1]") as string}
                     labelPlacement="end"
                   />
-                  {music.categories
+                  {(music.categories ?? [])
                     .map((cat) =>
                       typeof cat === "string" ? cat : cat.musicCategoryName
                     )
@@ -768,10 +773,12 @@ const MusicDetail: React.FC<unknown> = observer(() => {
             alignItems="center"
           >
             <Typography variant="subtitle1" style={{ fontWeight: 600 }}>
-              {t("music:category", { count: music.categories.length })}
+              {t("music:category", {
+                count: (music.categories ?? []).length,
+              })}
             </Typography>
             <Grid item>
-              {music.categories.map((elem) => {
+              {(music.categories ?? []).map((elem) => {
                 const cat =
                   typeof elem === "string" ? elem : elem.musicCategoryName;
                 return (

--- a/src/pages/music/MusicList.tsx
+++ b/src/pages/music/MusicList.tsx
@@ -38,6 +38,7 @@ import {
   useLocalStorage,
   useMusicTagName,
   useToggle,
+  useMusics,
 } from "../../utils";
 import InfiniteScroll from "../../components/helpers/InfiniteScroll";
 
@@ -84,7 +85,7 @@ const MusicList: React.FC<unknown> = observer(() => {
   const musicTagToName = useMusicTagName(contentTransMode);
   const getCharaName = useCharaName();
 
-  const [musicsCache] = useCachedData<IMusicInfo>("musics");
+  const [musicsCache] = useMusics();
   const [musicTags] = useCachedData<IMusicTagInfo>("musicTags");
   const [musicVocals] = useCachedData<IMusicVocalInfo>("musicVocals");
   const [outCharas] = useCachedData<IOutCharaProfile>("outsideCharacters");
@@ -180,7 +181,7 @@ const MusicList: React.FC<unknown> = observer(() => {
         if (
           musicMVTypes.length &&
           !musicMVTypes.every((type) =>
-            m.categories
+            (m.categories ?? [])
               .map((cat) =>
                 typeof cat === "string" ? cat : cat.musicCategoryName
               )

--- a/src/pages/music/MusicMeta.tsx
+++ b/src/pages/music/MusicMeta.tsx
@@ -16,11 +16,12 @@ import { OpenInNew, Search } from "@mui/icons-material";
 import React, { Fragment, useEffect } from "react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { IMusicDifficultyInfo, IMusicInfo, IMusicMeta } from "../../types.d";
+import { IMusicDifficultyInfo, IMusicMeta } from "../../types.d";
 import {
   addDataToMusicMeta,
   filterMusicMeta,
   useCachedData,
+  useMusics,
   useMusicMeta,
 } from "../../utils";
 // import AdSense from "../../components/blocks/AdSense";
@@ -34,7 +35,7 @@ const MusicMeta = () => {
   const { t } = useTranslation();
 
   const [metas] = useMusicMeta();
-  const [musics] = useCachedData<IMusicInfo>("musics");
+  const [musics] = useMusics();
   const [musicDifficulties] =
     useCachedData<IMusicDifficultyInfo>("musicDifficulties");
 

--- a/src/pages/user/sekai_profile/SekaiUserStatistics.tsx
+++ b/src/pages/user/sekai_profile/SekaiUserStatistics.tsx
@@ -23,7 +23,12 @@ import { useTranslation } from "react-i18next";
 import Image from "mui-image";
 import { charaIcons } from "../../../utils/resources";
 import DegreeImage from "../../../components/widgets/DegreeImage";
-import { getRemoteAssetURL, useCachedData, useToggle } from "../../../utils";
+import {
+  getRemoteAssetURL,
+  useCachedData,
+  useMusics,
+  useToggle,
+} from "../../../utils";
 import {
   IArea,
   IAreaItem,
@@ -317,7 +322,7 @@ const SekaiUserStatistics = observer(() => {
 
   const [areas] = useCachedData<IArea>("areas");
   const [areaItems] = useCachedData<IAreaItem>("areaItems");
-  const [musics] = useCachedData<IMusicInfo>("musics");
+  const [musics] = useMusics();
 
   const [characterRankOpen, toggleCharacterRankOpen] = useToggle(false);
   const [challengeLiveOpen, toggleChallengeLiveOpen] = useToggle(false);

--- a/src/pages/virtual_live/VirtualLiveStepMusic.tsx
+++ b/src/pages/virtual_live/VirtualLiveStepMusic.tsx
@@ -2,7 +2,7 @@ import { Grid, Typography } from "@mui/material";
 import React, { Fragment, useLayoutEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { IMusicInfo, IMusicVocalInfo, VirtualLiveSetlist } from "../../types.d";
-import { getRemoteAssetURL, useCachedData } from "../../utils";
+import { getRemoteAssetURL, useCachedData, useMusics } from "../../utils";
 import AudioPlayer from "../music/AudioPlayer";
 import {
   CharaNameTrans,
@@ -15,7 +15,7 @@ const VirtualLiveStepMusic: React.FC<{
 }> = ({ data }) => {
   const { t } = useTranslation();
 
-  const [musics] = useCachedData<IMusicInfo>("musics");
+  const [musics] = useMusics();
   const [musicVocals] = useCachedData<IMusicVocalInfo>("musicVocals");
 
   const [music, setMusic] = useState<IMusicInfo>();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -185,17 +185,18 @@ export interface GachaStatistic {
   counts: number[];
 }
 
+export type IMusicCategoryName =
+  | string
+  | {
+      musicCategoryName: string;
+      startAt: number;
+    };
+
 export interface IMusicInfo {
   id: number;
   seq: number;
   releaseConditionId: number;
-  categories: (
-    | string
-    | {
-        musicCategoryName: string;
-        startAt: number;
-      }
-  )[];
+  categories?: IMusicCategoryName[];
   title: string;
   pronunciation: string;
   creatorArtistId: number;
@@ -215,6 +216,13 @@ export interface IMusicInfo {
   musicCollaborationId?: number;
   creator?: string;
   infos?: any[];
+}
+
+export interface IMusicCategory {
+  musicId: number;
+  musicCategoryName: string;
+  startAt?: number;
+  musicCategoryType?: string;
 }
 
 export interface IMusicAchievement {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -94,7 +94,9 @@ import {
   IMysekaiGameCharacterUnitGroups,
   ICardSupply,
   ICardSupplyGroup,
+  IMusicCategory,
 } from "./../types.d";
+import { fetchMusicCategories, mergeMusicCategories } from "./musicCategories";
 import { useAssetI18n } from "./i18n";
 import { useLocation } from "react-router-dom";
 import useSWR from "swr";
@@ -385,6 +387,34 @@ export function useCachedData<
   const { data, error } = useSWR(`${region}|${name}`, fetchCached);
 
   return [data, !error && !data, error];
+}
+
+export function useMusics(): [IMusicInfo[] | undefined, boolean, unknown] {
+  const { region } = useRootStore();
+
+  const [musics, isLoading, error] = useCachedData<IMusicInfo>("musics");
+
+  // All regions may ship a standalone `musicCategories.json`. The fetch is
+  // best-effort: `fetchMusicCategories` swallows any failure (404, network
+  // error, malformed body) and resolves to `undefined`, so a missing file
+  // never breaks the main `musics` request or the page. The error is
+  // intentionally not surfaced as this hook's error/loading state — the main
+  // musics `data`/`error` remain fully independent.
+  const { data: musicCategories } = useSWR<IMusicCategory[] | undefined>(
+    `${region}|musicCategories`,
+    () => fetchMusicCategories(region),
+    {
+      shouldRetryOnError: false,
+      revalidateOnFocus: false,
+    }
+  );
+
+  const merged = useMemo(() => {
+    if (!musics) return undefined;
+    return mergeMusicCategories(musics, musicCategories);
+  }, [musics, musicCategories]);
+
+  return [merged, isLoading && !merged, error];
 }
 
 export function useCompactData<

--- a/src/utils/musicCategories.test.ts
+++ b/src/utils/musicCategories.test.ts
@@ -1,0 +1,167 @@
+import axios from "axios";
+import { describe, expect, it, vi } from "vitest";
+import { fetchMusicCategories, mergeMusicCategories } from "./musicCategories";
+import { IMusicCategory, IMusicInfo } from "../types";
+
+vi.mock("axios", () => ({
+  default: { get: vi.fn() },
+}));
+
+const mockedGet = axios.get as unknown as ReturnType<typeof vi.fn>;
+
+function makeMusic(overrides: Partial<IMusicInfo> = {}): IMusicInfo {
+  return {
+    id: 1,
+    seq: 1,
+    releaseConditionId: 0,
+    title: "Test Music",
+    pronunciation: "",
+    creatorArtistId: 0,
+    lyricist: "Lyricist",
+    composer: "Composer",
+    arranger: "Arranger",
+    dancerCount: 0,
+    selfDancerPosition: 0,
+    assetbundleName: "test_music",
+    publishedAt: 0,
+    fillerSec: 0,
+    ...overrides,
+  } as IMusicInfo;
+}
+
+describe("mergeMusicCategories", () => {
+  it("keeps old-format categories already present on the entry", () => {
+    const musics = [makeMusic({ id: 1, categories: ["mv", "original"] })];
+
+    const result = mergeMusicCategories(musics, undefined);
+
+    expect(result[0].categories).toEqual(["mv", "original"]);
+  });
+
+  it("keeps old-format entries untouched when external categories are provided", () => {
+    const musics = [
+      makeMusic({ id: 1, categories: ["mv"] }),
+      makeMusic({ id: 2, categories: ["original"] }),
+    ];
+    const external: IMusicCategory[] = [
+      { musicId: 1, musicCategoryName: "mv_2d", startAt: 0 },
+    ];
+
+    const result = mergeMusicCategories(musics, external);
+
+    // existing inline categories win, external records are ignored for them
+    expect(result[0].categories).toEqual(["mv"]);
+    expect(result[1].categories).toEqual(["original"]);
+  });
+
+  it("derives categories for new JP format entries from the standalone file", () => {
+    const musics = [makeMusic({ id: 10 }), makeMusic({ id: 20 })];
+    const external: IMusicCategory[] = [
+      { musicId: 10, musicCategoryName: "mv", startAt: 1000 },
+      { musicId: 20, musicCategoryName: "original" },
+    ];
+
+    const result = mergeMusicCategories(musics, external);
+
+    expect(result[0].categories).toEqual([
+      { musicCategoryName: "mv", startAt: 1000 },
+    ]);
+    expect(result[1].categories).toEqual(["original"]);
+  });
+
+  it("preserves a startAt of 0 (does not treat 0 as missing)", () => {
+    const musics = [makeMusic({ id: 20 })];
+    const external: IMusicCategory[] = [
+      { musicId: 20, musicCategoryName: "original", startAt: 0 },
+    ];
+
+    const result = mergeMusicCategories(musics, external);
+
+    expect(result[0].categories).toEqual([
+      { musicCategoryName: "original", startAt: 0 },
+    ]);
+  });
+
+  it("falls back to [] when an entry has no categories and no matching record", () => {
+    const musics = [makeMusic({ id: 99 })];
+    const external: IMusicCategory[] = [
+      { musicId: 1, musicCategoryName: "mv" },
+    ];
+
+    const result = mergeMusicCategories(musics, external);
+
+    expect(result[0].categories).toEqual([]);
+  });
+
+  it("handles duplicate / multiple categories for a single music", () => {
+    const musics = [makeMusic({ id: 5 })];
+    const external: IMusicCategory[] = [
+      { musicId: 5, musicCategoryName: "mv", startAt: 100 },
+      { musicId: 5, musicCategoryName: "image", startAt: 200 },
+    ];
+
+    const result = mergeMusicCategories(musics, external);
+
+    expect(result[0].categories).toEqual([
+      { musicCategoryName: "mv", startAt: 100 },
+      { musicCategoryName: "image", startAt: 200 },
+    ]);
+  });
+
+  it("does not mutate the original musics input", () => {
+    const musics = [makeMusic({ id: 5 })];
+    const external: IMusicCategory[] = [
+      { musicId: 5, musicCategoryName: "mv", startAt: 0 },
+    ];
+
+    const before = JSON.stringify(musics);
+    mergeMusicCategories(musics, external);
+
+    expect(JSON.stringify(musics)).toEqual(before);
+  });
+
+  it("falls back safely when the external file could not be fetched (e.g. 404/network error for a region without the file)", () => {
+    const musics = [
+      makeMusic({ id: 1, categories: ["mv"] }),
+      makeMusic({ id: 2 }), // dirty entry missing categories
+    ];
+
+    const result = mergeMusicCategories(musics, undefined);
+
+    // preserved inline categories
+    expect(result[0].categories).toEqual(["mv"]);
+    // missing categories normalized to [] instead of crashing downstream
+    expect(result[1].categories).toEqual([]);
+  });
+});
+
+describe("fetchMusicCategories", () => {
+  it("returns parsed categories on a successful response", async () => {
+    mockedGet.mockResolvedValue({
+      data: [{ musicId: 1, musicCategoryName: "mv", startAt: 0 }],
+    });
+
+    const result = await fetchMusicCategories("jp");
+
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { musicId: 1, musicCategoryName: "mv", startAt: 0 },
+    ]);
+  });
+
+  it("swallows 404 / network errors and resolves to undefined", async () => {
+    mockedGet.mockRejectedValue(new Error("Request failed with status 404"));
+
+    const result = await fetchMusicCategories("en");
+
+    expect(result).toBeUndefined();
+  });
+
+  it("swallows malformed-body errors and resolves to undefined", async () => {
+    mockedGet.mockRejectedValue(new Error("Unexpected token in JSON"));
+
+    const result = await fetchMusicCategories("kr");
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/utils/musicCategories.ts
+++ b/src/utils/musicCategories.ts
@@ -1,0 +1,98 @@
+import Axios from "axios";
+import { masterUrl } from "./urls";
+import {
+  IMusicCategory,
+  IMusicCategoryName,
+  IMusicInfo,
+  ServerRegion,
+} from "../types";
+
+/**
+ * Build the `categories` field for a music entry from its associated
+ * `musicCategories` records (the separate `musicCategories.json` file).
+ *
+ * - When a record has a `startAt`, it is represented as an object
+ *   `{ musicCategoryName, startAt }`, matching the existing optional shape.
+ *   Note: `startAt` may legitimately be `0`, so presence is checked with
+ *   `!== undefined` rather than truthiness.
+ * - Otherwise it is represented as the plain category name string.
+ */
+function deriveCategories(records: IMusicCategory[]): IMusicCategoryName[] {
+  return records.map((record) => {
+    if (record.startAt !== undefined) {
+      return {
+        musicCategoryName: record.musicCategoryName,
+        startAt: record.startAt,
+      };
+    }
+    return record.musicCategoryName;
+  });
+}
+
+/**
+ * Fetch the standalone `musicCategories.json` for a region.
+ *
+ * This request is best-effort: the file only exists for some regions (e.g.
+ * jp). Any failure (404, network error, malformed body) is swallowed and
+ * resolved to `undefined` so that callers fall back to inline `categories`
+ * and never throw. The error is intentionally not propagated.
+ */
+export async function fetchMusicCategories(
+  region: ServerRegion
+): Promise<IMusicCategory[] | undefined> {
+  try {
+    const urlBase = masterUrl["ww"][region];
+    const { data } = await Axios.get<IMusicCategory[]>(
+      `${urlBase}/musicCategories.json`
+    );
+    return data;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Merge the standalone `musicCategories` association records into a list of
+ * musics.
+ *
+ * Rules (keep old-format data intact, support the new JP split dataset):
+ * 1. If a music entry already has a `categories` field, keep it as-is
+ *    (old-format compatibility).
+ * 2. Otherwise (new JP format where `musics.json` no longer ships
+ *    `categories`), derive the categories from the association records keyed
+ *    by `musicId`.
+ * 3. If there are no association records for a music, fall back to `[]`.
+ *
+ * When `categories` is `undefined` (e.g. a region without a
+ * `musicCategories.json`), musics are returned unchanged except that any
+ * entry missing the `categories` field is normalized to `[]` so downstream
+ * consumers never crash on undefined data.
+ */
+export function mergeMusicCategories(
+  musics: IMusicInfo[],
+  categories?: IMusicCategory[]
+): IMusicInfo[] {
+  const byMusic = categories?.length
+    ? categories.reduce((map, category) => {
+        const list = map.get(category.musicId) ?? [];
+        list.push(category);
+        map.set(category.musicId, list);
+        return map;
+      }, new Map<number, IMusicCategory[]>())
+    : undefined;
+
+  return musics.map((music) => {
+    // Old-format data already carries its own categories: keep untouched.
+    if (music.categories !== undefined) {
+      return music;
+    }
+
+    // New JP format: derive from association records, if any.
+    const records = byMusic?.get(music.id);
+    if (!records || !records.length) {
+      return { ...music, categories: [] };
+    }
+
+    return { ...music, categories: deriveCategories(records) };
+  });
+}


### PR DESCRIPTION
## Summary
- support standalone `musicCategories.json` data and merge it into music records by `musicId`
- make `IMusicInfo.categories` optional and guard all music category consumers
- treat missing, 404, malformed, or failed category requests as an empty fallback without affecting `musics.json`
- add regression tests for legacy inline categories, standalone categories, `startAt: 0`, and fetch failures

## Validation
- `pnpm test` ✅
- `pnpm lint` ✅ (existing warnings only)
- `pnpm build` ✅
- `pnpm tsc --noEmit` has 13 pre-existing errors in unrelated StoryReader/ChibiPlayer files