### PR TITLE
fix(music): support duplicate 2DMV asset variants

### DIFF
--- a/src/pages/music/MusicDetail.tsx
+++ b/src/pages/music/MusicDetail.tsx
@@ -16,7 +16,13 @@ import {
 import { Alert } from "@mui/material";
 import { TabContext, TabPanel } from "@mui/lab";
 import { OpenInNew } from "@mui/icons-material";
-import React, { Fragment, useCallback, useEffect, useState } from "react";
+import React, {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useParams } from "react-router-dom";
 import Viewer from "react-viewer";
 import {
@@ -26,6 +32,7 @@ import {
   IMusicInfo,
   IMusicTagInfo,
   IMusicVocalInfo,
+  IMusicAssetVariant,
   IOutCharaProfile,
   IMusicOriginal,
 } from "../../types.d";
@@ -105,6 +112,8 @@ const MusicDetail: React.FC<unknown> = observer(() => {
   const [musicAchievements] =
     useCachedData<IMusicAchievement>("musicAchievements");
   const [musicOriginals] = useCachedData<IMusicOriginal>("musicOriginals");
+  const [musicAssetVariants] =
+    useCachedData<IMusicAssetVariant>("musicAssetVariants");
 
   const { musicId } = useParams<{ musicId: string }>();
 
@@ -135,6 +144,51 @@ const MusicDetail: React.FC<unknown> = observer(() => {
   const [musicCommentId, setMusicCommentId] = useState<number>(0);
   const [format, setFormat] = useState<"mp3" | "flac" | "wav">("mp3");
   const [isExclusiveSong, setIsExclusiveSong] = useState(false);
+
+  const videoChoices = useMemo(
+    () =>
+      (music?.categories ?? [])
+        .map((category, index) => {
+          const categoryName =
+            typeof category === "string"
+              ? category
+              : category.musicCategoryName;
+          return {
+            categoryName,
+            index,
+            musicAssetVariantId:
+              typeof category === "string"
+                ? undefined
+                : category.musicAssetVariantId,
+            variant:
+              typeof category === "string" ||
+              category.musicAssetVariantId === undefined
+                ? undefined
+                : musicAssetVariants?.find(
+                    (assetVariant) =>
+                      assetVariant.id === category.musicAssetVariantId
+                  ),
+            value: `music-video-${categoryName}-${
+              typeof category === "string"
+                ? "default"
+                : (category.musicAssetVariantId ?? "default")
+            }-${index}`,
+          };
+        })
+        .filter(({ categoryName }) =>
+          ["original", "mv_2d"].includes(categoryName)
+        ),
+    [music, musicAssetVariants]
+  );
+
+  const videoChoiceCounts = useMemo(
+    () =>
+      videoChoices.reduce<Record<string, number>>((counts, choice) => {
+        counts[choice.categoryName] = (counts[choice.categoryName] ?? 0) + 1;
+        return counts;
+      }, {}),
+    [videoChoices]
+  );
 
   useEffect(() => {
     if (music) {
@@ -257,40 +311,61 @@ const MusicDetail: React.FC<unknown> = observer(() => {
   }, [getMusic, music]);
 
   useEffect(() => {
+    const selectedChoice = videoChoices.find(
+      (choice) => choice.value === vocalPreviewVal
+    );
+    if (!selectedChoice?.musicAssetVariantId || !selectedChoice.variant) return;
+
+    const vocalIndex = musicVocal.findIndex(
+      (vocal) => vocal.id === selectedChoice.variant?.musicVocalId
+    );
+    if (vocalIndex >= 0 && vocalIndex !== selectedPreviewVocalType) {
+      setSelectedPreviewVocalType(vocalIndex);
+    }
+  }, [musicVocal, selectedPreviewVocalType, videoChoices, vocalPreviewVal]);
+
+  useEffect(() => {
     if (
       music &&
       musicVocal &&
       musicVocal[selectedPreviewVocalType] &&
-      (vocalPreviewVal === "original" || vocalPreviewVal === "mv_2d")
+      (videoChoices.some((choice) => choice.value === vocalPreviewVal) ||
+        vocalPreviewVal === "original" ||
+        vocalPreviewVal === "mv_2d")
     ) {
-      if (
-        (TW_EXCLUSIVE_IDS.includes(music.id) && region === "tw") ||
-        (EN_EXCLUSIVE_IDS.includes(music.id) && region === "en") ||
-        (KR_EXCLUSIVE_IDS.includes(music.id) && region === "kr") ||
-        (CN_EXCLUSIVE_IDS.includes(music.id) && region === "cn")
-      ) {
-        setMusicVideoURL(
-          `live/2dmode/${
-            vocalPreviewVal === "original"
-              ? "original_mv"
-              : vocalPreviewVal === "mv_2d"
-                ? "sekai_mv"
-                : ""
-          }/${String(music.id).padStart(4, "0")}/`
-        );
-      } else {
-        setMusicVideoURL(
-          `live/2dmode/${
-            vocalPreviewVal === "original"
-              ? "original_mv"
-              : vocalPreviewVal === "mv_2d"
-                ? "sekai_mv"
-                : ""
-          }/${String(music.id).padStart(4, "0")}/`
-        );
+      const selectedChoice = videoChoices.find(
+        (choice) => choice.value === vocalPreviewVal
+      );
+      const categoryName = selectedChoice?.categoryName ?? vocalPreviewVal;
+
+      // Wait for the variant record rather than accidentally playing the
+      // default music-id directory while the cache is still loading.
+      if (selectedChoice?.musicAssetVariantId && !selectedChoice.variant) {
+        setMusicVideoURL("");
+        return;
       }
+
+      setMusicVideoURL(
+        `live/2dmode/${
+          categoryName === "original"
+            ? "original_mv"
+            : categoryName === "mv_2d"
+              ? "sekai_mv"
+              : ""
+        }/${
+          selectedChoice?.variant?.assetbundleName ??
+          String(music.id).padStart(4, "0")
+        }/`
+      );
     }
-  }, [music, musicVocal, region, selectedPreviewVocalType, vocalPreviewVal]);
+  }, [
+    music,
+    musicVocal,
+    region,
+    selectedPreviewVocalType,
+    videoChoices,
+    vocalPreviewVal,
+  ]);
 
   const getVocalCharaIcons: (index: number) => JSX.Element = useCallback(
     (index: number) => {
@@ -510,9 +585,12 @@ const MusicDetail: React.FC<unknown> = observer(() => {
         {getTranslated(`music_titles:${musicId}`, music.title)}
       </TypographyHeader>
       <ContainerContent maxWidth="md">
-        {["original", "mv_2d"].includes(vocalPreviewVal) &&
+        {(videoChoices.some((choice) => choice.value === vocalPreviewVal) ||
+          vocalPreviewVal === "original" ||
+          vocalPreviewVal === "mv_2d") &&
         musicVocalTypes.length &&
         musicVocal.length &&
+        musicVideoURL &&
         longMusicPlaybackURL ? (
           <MusicVideoPlayer
             audioPath={longMusicPlaybackURL}
@@ -565,6 +643,15 @@ const MusicDetail: React.FC<unknown> = observer(() => {
                   onChange={(e, v) => {
                     setVocalPreviewVal(v);
                     setVocalDisabled(false);
+                    const selectedChoice = videoChoices.find(
+                      (choice) => choice.value === v
+                    );
+                    const vocalIndex = musicVocal.findIndex(
+                      (vocal) =>
+                        vocal.id === selectedChoice?.variant?.musicVocalId
+                    );
+                    if (vocalIndex >= 0)
+                      setSelectedPreviewVocalType(vocalIndex);
                   }}
                 >
                   <FormControlLabel
@@ -579,20 +666,39 @@ const MusicDetail: React.FC<unknown> = observer(() => {
                     label={t("music:vocalTab.title[1]") as string}
                     labelPlacement="end"
                   />
-                  {(music.categories ?? [])
-                    .map((cat) =>
-                      typeof cat === "string" ? cat : cat.musicCategoryName
-                    )
-                    .filter((cat) => ["original", "mv_2d"].includes(cat))
-                    .map((cat) => (
+                  {videoChoices.map((choice) => {
+                    const categoryLabel = t(
+                      `music:categoryType.${choice.categoryName}`
+                    ) as string;
+                    const matchingVocal = choice.variant
+                      ? musicVocal.find(
+                          (vocal) => vocal.id === choice.variant?.musicVocalId
+                        )
+                      : undefined;
+                    const label =
+                      videoChoiceCounts[choice.categoryName] > 1 &&
+                      choice.musicAssetVariantId
+                        ? `${categoryLabel} (${
+                            matchingVocal
+                              ? getTranslated(
+                                  `music_vocal:${matchingVocal.musicVocalType}`,
+                                  matchingVocal.caption
+                                )
+                              : (choice.variant?.assetbundleName ??
+                                `#${choice.musicAssetVariantId}`)
+                          })`
+                        : categoryLabel;
+
+                    return (
                       <FormControlLabel
-                        value={cat}
+                        value={choice.value}
                         control={<Radio color="primary"></Radio>}
-                        label={t(`music:categoryType.${cat}`) as string}
+                        label={label}
                         labelPlacement="end"
-                        key={cat}
+                        key={choice.value}
                       />
-                    ))}
+                    );
+                  })}
                   {!!musicOriginal && (
                     <FormControlLabel
                       value="original_video"

--- a/src/pages/music/MusicDetail.tsx
+++ b/src/pages/music/MusicDetail.tsx
@@ -345,14 +345,10 @@ const MusicDetail: React.FC<unknown> = observer(() => {
         return;
       }
 
+      const videoDirectory =
+        categoryName === "original" ? "original_mv" : "sekai_mv";
       setMusicVideoURL(
-        `live/2dmode/${
-          categoryName === "original"
-            ? "original_mv"
-            : categoryName === "mv_2d"
-              ? "sekai_mv"
-              : ""
-        }/${
+        `live/2dmode/${videoDirectory}/${
           selectedChoice?.variant?.assetbundleName ??
           String(music.id).padStart(4, "0")
         }/`
@@ -675,19 +671,27 @@ const MusicDetail: React.FC<unknown> = observer(() => {
                           (vocal) => vocal.id === choice.variant?.musicVocalId
                         )
                       : undefined;
-                    const label =
+                    let label = categoryLabel;
+                    if (
                       videoChoiceCounts[choice.categoryName] > 1 &&
                       choice.musicAssetVariantId
-                        ? `${categoryLabel} (${
-                            matchingVocal
-                              ? getTranslated(
-                                  `music_vocal:${matchingVocal.musicVocalType}`,
-                                  matchingVocal.caption
-                                )
-                              : (choice.variant?.assetbundleName ??
-                                `#${choice.musicAssetVariantId}`)
-                          })`
-                        : categoryLabel;
+                    ) {
+                      let variantLabel = `#${choice.musicAssetVariantId}`;
+                      const assetbundleName = choice.variant?.assetbundleName;
+                      if (
+                        assetbundleName !== undefined &&
+                        assetbundleName !== null
+                      ) {
+                        variantLabel = assetbundleName;
+                      }
+                      if (matchingVocal) {
+                        variantLabel = getTranslated(
+                          `music_vocal:${matchingVocal.musicVocalType}`,
+                          matchingVocal.caption
+                        );
+                      }
+                      label = `${categoryLabel} (${variantLabel})`;
+                    }
 
                     return (
                       <FormControlLabel

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -191,7 +191,8 @@ export type IMusicCategoryName =
   | string
   | {
       musicCategoryName: string;
-      startAt: number;
+      startAt?: number;
+      musicAssetVariantId?: number;
     };
 
 export interface IMusicInfo {
@@ -224,7 +225,16 @@ export interface IMusicCategory {
   musicId: number;
   musicCategoryName: string;
   startAt?: number;
+  musicAssetVariantId?: number;
   musicCategoryType?: string;
+}
+
+export interface IMusicAssetVariant {
+  id: number;
+  musicVocalId: number;
+  seq: number;
+  musicAssetType: string;
+  assetbundleName: string;
 }
 
 export interface IMusicAchievement {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -95,6 +95,7 @@ import {
   ICardSupply,
   ICardSupplyGroup,
   IMusicCategory,
+  IMusicAssetVariant,
 } from "./../types.d";
 import { fetchMusicCategories, mergeMusicCategories } from "./musicCategories";
 import { useAssetI18n } from "./i18n";
@@ -370,7 +371,8 @@ export function useCachedData<
     | IMysekaiTalk
     | IMysekaiGameCharacterUnitGroups
     | ICardSupply
-    | ICardSupplyGroup,
+    | ICardSupplyGroup
+    | IMusicAssetVariant,
 >(name: string): [T[] | undefined, boolean, unknown] {
   // const [cached, cachedRef, setCached] = useRefState<T[]>([]);
   const { region } = useRootStore();

--- a/src/utils/musicCategories.test.ts
+++ b/src/utils/musicCategories.test.ts
@@ -82,6 +82,49 @@ describe("mergeMusicCategories", () => {
     ]);
   });
 
+  it("preserves a music asset variant ID for duplicate category names", () => {
+    const musics = [makeMusic({ id: 477 })];
+    const external: IMusicCategory[] = [
+      { musicId: 477, musicCategoryName: "mv" },
+      { musicId: 477, musicCategoryName: "mv_2d" },
+      {
+        musicId: 477,
+        musicCategoryName: "mv_2d",
+        musicAssetVariantId: 47701,
+      },
+    ];
+
+    const result = mergeMusicCategories(musics, external);
+
+    expect(result[0].categories).toEqual([
+      "mv",
+      "mv_2d",
+      { musicCategoryName: "mv_2d", musicAssetVariantId: 47701 },
+    ]);
+  });
+
+  it("preserves startAt and music asset variant ID together", () => {
+    const musics = [makeMusic({ id: 20 })];
+    const external: IMusicCategory[] = [
+      {
+        musicId: 20,
+        musicCategoryName: "mv_2d",
+        startAt: 0,
+        musicAssetVariantId: 47701,
+      },
+    ];
+
+    const result = mergeMusicCategories(musics, external);
+
+    expect(result[0].categories).toEqual([
+      {
+        musicCategoryName: "mv_2d",
+        startAt: 0,
+        musicAssetVariantId: 47701,
+      },
+    ]);
+  });
+
   it("falls back to [] when an entry has no categories and no matching record", () => {
     const musics = [makeMusic({ id: 99 })];
     const external: IMusicCategory[] = [

--- a/src/utils/musicCategories.ts
+++ b/src/utils/musicCategories.ts
@@ -11,19 +11,26 @@ import {
  * Build the `categories` field for a music entry from its associated
  * `musicCategories` records (the separate `musicCategories.json` file).
  *
- * - When a record has a `startAt`, it is represented as an object
- *   `{ musicCategoryName, startAt }`, matching the existing optional shape.
- *   Note: `startAt` may legitimately be `0`, so presence is checked with
+ * - When a record has a `startAt` or `musicAssetVariantId`, it is represented
+ *   as an object preserving those values, matching the existing optional
+ *   shape. Both values may legitimately be `0`, so presence is checked with
  *   `!== undefined` rather than truthiness.
  * - Otherwise it is represented as the plain category name string.
  */
 function deriveCategories(records: IMusicCategory[]): IMusicCategoryName[] {
   return records.map((record) => {
-    if (record.startAt !== undefined) {
-      return {
+    if (
+      record.startAt !== undefined ||
+      record.musicAssetVariantId !== undefined
+    ) {
+      const category: Exclude<IMusicCategoryName, string> = {
         musicCategoryName: record.musicCategoryName,
-        startAt: record.startAt,
       };
+      if (record.startAt !== undefined) category.startAt = record.startAt;
+      if (record.musicAssetVariantId !== undefined) {
+        category.musicAssetVariantId = record.musicAssetVariantId;
+      }
+      return category;
     }
     return record.musicCategoryName;
   });


### PR DESCRIPTION
## Summary
- preserve `musicAssetVariantId` when merging standalone music categories
- load typed `musicAssetVariants` data and render duplicate 2DMV records as separate choices
- use each variant's `assetbundleName` and synchronize its associated vocal for playback

## Validation
- `pnpm test` (14 tests passed)
- `pnpm build`
- targeted ESLint
- `git diff --check`

The default and JP music 477 variant MP4 resources were also verified with HTTP 200 responses. `tsc --noEmit` remains affected by pre-existing Live2D/FFmpeg type errors unrelated to this change.